### PR TITLE
feat: Add blog automation API and dynamic news pages

### DIFF
--- a/src/app/api/blog/posts/[slug]/route.ts
+++ b/src/app/api/blog/posts/[slug]/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { NewsPost } from '@/types';
+
+// In-memory storage (in production, use a database)
+let blogPosts: NewsPost[] = [
+  {
+    id: '1',
+    title: 'Alki Drops New Single "221"',
+    slug: 'alki-221-release',
+    excerpt: 'Alki returns with his most aggressive track yet...',
+    content: 'Full content here...',
+    publishedAt: new Date('2025-01-17'),
+    author: 'HLPFL Team',
+    category: 'Releases',
+    image: '/images/team/IMG_2768.png',
+  },
+];
+
+// GET: Fetch single blog post by slug
+export async function GET(
+  request: Request,
+  { params }: { params: { slug: string } }
+) {
+  try {
+    const { slug } = params;
+    
+    const post = blogPosts.find(post => post.slug === slug);
+    
+    if (!post) {
+      return NextResponse.json(
+        { success: false, error: 'Post not found' },
+        { status: 404 }
+      );
+    }
+    
+    return NextResponse.json({
+      success: true,
+      post,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch post' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/blog/posts/route.ts
+++ b/src/app/api/blog/posts/route.ts
@@ -1,0 +1,137 @@
+import { NextResponse } from 'next/server';
+import { NewsPost } from '@/types';
+
+// In-memory storage (replace with database in production)
+let blogPosts: NewsPost[] = [
+  {
+    id: '1',
+    title: 'Alki Drops New Single "221"',
+    slug: 'alki-221-release',
+    excerpt: 'Alki returns with his most aggressive track yet, "221" - an angsty rap record that pulls no punches.',
+    content: 'Alki returns with his most aggressive track yet, "221" - an angsty rap record that pulls no punches. This new single showcases Alki\'s evolution as an artist, blending raw emotion with his signature alternative sound.\n\nThe track, which drops this Friday, represents a bold new direction for HLPFL\'s first signed artist. "221" delivers the kind of authenticity and energy that has earned Alki nearly 50,000 monthly listeners on Spotify and millions of streams across platforms.\n\nFans can expect the same unfiltered honesty that made "Switched Up" a breakout hit, but with an even harder edge. The production is darker, the lyrics more personal, and the overall vibe more intense than anything we\'ve released before.\n\nThis single marks the beginning of an exciting new chapter for Alki and HLPFL. We\'re not just releasing music - we\'re building a movement that puts artists first and creates genuine connections with fans.',
+    publishedAt: new Date('2025-01-17'),
+    author: 'HLPFL Team',
+    category: 'Releases',
+    image: '/images/team/IMG_2768.png',
+  },
+  {
+    id: '2',
+    title: 'Alki Surpasses 3 Million Streams on "Switched Up"',
+    slug: 'switched-up-milestone',
+    excerpt: 'Celebrating a major milestone as Alki\'s breakout hit continues to resonate with fans worldwide.',
+    content: 'Celebrating a major milestone as Alki\'s breakout hit continues to resonate with fans worldwide. The track has now surpassed 3 million streams across all platforms, solidifying Alki\'s position as one of the most exciting emerging artists in the alternative space.\n\n"Switched Up" has been on an incredible journey since its release. From viral TikTok moments to Spotify playlist placements, the song has found its way into the hearts of millions of listeners who connect with its raw energy and authentic message.\n\nThis milestone isn\'t just about numbers - it\'s about proving that independent artists can thrive when they have the right partnership. Alki\'s success with HLPFL demonstrates the power of our 50/50 model, where artists retain ownership and control while getting the support they need to reach their audience.\n\nThank you to every fan who has streamed, shared, and supported this track. We\'re just getting started, and there\'s much more to come from Alki and the HLPFL family.',
+    publishedAt: new Date('2024-12-15'),
+    author: 'HLPFL Team',
+    category: 'News',
+  },
+];
+
+// GET: Fetch all blog posts
+export async function GET() {
+  try {
+    return NextResponse.json({
+      success: true,
+      posts: blogPosts.sort((a, b) => 
+        new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
+      ),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch posts' },
+      { status: 500 }
+    );
+  }
+}
+
+// POST: Create new blog post
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    
+    // Validate required fields
+    if (!body.title || !body.slug || !body.content) {
+      return NextResponse.json(
+        { success: false, error: 'Missing required fields: title, slug, content' },
+        { status: 400 }
+      );
+    }
+    
+    // Check for duplicate slug
+    const slugExists = blogPosts.some(post => post.slug === body.slug);
+    if (slugExists) {
+      return NextResponse.json(
+        { success: false, error: 'A post with this slug already exists' },
+        { status: 409 }
+      );
+    }
+    
+    // Create new post
+    const newPost: NewsPost = {
+      id: body.id || Date.now().toString(),
+      title: body.title,
+      slug: body.slug,
+      excerpt: body.excerpt || body.content.substring(0, 200) + '...',
+      content: body.content,
+      publishedAt: body.publishedAt ? new Date(body.publishedAt) : new Date(),
+      author: body.author || 'HLPFL Team',
+      category: body.category || 'News',
+      image: body.image || undefined,
+    };
+    
+    // Add to beginning of array (newest first)
+    blogPosts.unshift(newPost);
+    
+    return NextResponse.json(
+      { 
+        success: true, 
+        post: newPost,
+        message: 'Blog post created successfully'
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error('Error creating post:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to create post' },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE: Delete a blog post
+export async function DELETE(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get('id');
+    
+    if (!id) {
+      return NextResponse.json(
+        { success: false, error: 'Post ID is required' },
+        { status: 400 }
+      );
+    }
+    
+    const initialLength = blogPosts.length;
+    blogPosts = blogPosts.filter(post => post.id !== id);
+    
+    if (blogPosts.length === initialLength) {
+      return NextResponse.json(
+        { success: false, error: 'Post not found' },
+        { status: 404 }
+      );
+    }
+    
+    return NextResponse.json(
+      { 
+        success: true, 
+        message: 'Post deleted successfully' 
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, error: 'Failed to delete post' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/news/[slug]/page.tsx
+++ b/src/app/news/[slug]/page.tsx
@@ -1,0 +1,171 @@
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import { Calendar, User, ArrowLeft, Share2 } from 'lucide-react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/Button'
+import { Card } from '@/components/ui/Card'
+import { formatDate } from '@/lib/utils'
+
+async function getBlogPost(slug: string) {
+  try {
+    // Try to fetch from API first
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000'}/api/blog/posts/${slug}`, {
+      cache: 'no-store'
+    })
+    
+    if (response.ok) {
+      const data = await response.json()
+      if (data.success) {
+        return data.post
+      }
+    }
+  } catch (error) {
+    console.error('Error fetching from API:', error)
+  }
+
+  // Fallback to mockData
+  const { mockNews } = await import('@/data/mockData')
+  return mockNews.find(post => post.slug === slug)
+}
+
+export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
+  const post = await getBlogPost(params.slug)
+
+  if (!post) {
+    return {
+      title: 'Post Not Found | HLPFL',
+    }
+  }
+
+  return {
+    title: `${post.title} | HLPFL`,
+    description: post.excerpt,
+    openGraph: {
+      title: post.title,
+      description: post.excerpt,
+      images: post.image ? [post.image] : [],
+      type: 'article',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.excerpt,
+      images: post.image ? [post.image] : [],
+    },
+  }
+}
+
+export default async function BlogPostPage({ params }: { params: { slug: string } }) {
+  const post = await getBlogPost(params.slug)
+
+  if (!post) {
+    notFound()
+  }
+
+  return (
+    <div className="min-h-screen bg-dark">
+      {/* Header */}
+      <header className="py-8 px-4 border-b border-gray-800">
+        <div className="max-w-4xl mx-auto">
+          <Link href="/news">
+            <Button variant="ghost" size="sm">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to News
+            </Button>
+          </Link>
+        </div>
+      </header>
+
+      {/* Article Content */}
+      <article className="py-12 px-4">
+        <div className="max-w-4xl mx-auto">
+          {/* Article Header */}
+          <header className="mb-12">
+            <div className="flex items-center space-x-4 mb-6">
+              <span className="bg-gold/10 text-gold px-3 py-1 rounded-full text-sm font-medium capitalize">
+                {post.category}
+              </span>
+              <span className="text-gray-500 text-sm">•</span>
+              <span className="text-gray-400 text-sm">
+                {formatDate(post.publishedAt)}
+              </span>
+            </div>
+
+            <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
+              {post.title}
+            </h1>
+
+            <p className="text-xl text-gray-300 leading-relaxed mb-8">
+              {post.excerpt}
+            </p>
+
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-4">
+                <div className="w-12 h-12 bg-gold/10 rounded-full flex items-center justify-center">
+                  <User className="w-6 h-6 text-gold" />
+                </div>
+                <div>
+                  <p className="text-white font-medium">{post.author}</p>
+                  <p className="text-gray-400 text-sm">HLPFL Team</p>
+                </div>
+              </div>
+
+              <Button variant="outline" size="sm">
+                <Share2 className="mr-2 h-4 w-4" />
+                Share
+              </Button>
+            </div>
+          </header>
+
+          {/* Featured Image */}
+          {post.image && (
+            <div className="mb-12 rounded-lg overflow-hidden">
+              <img
+                src={post.image}
+                alt={post.title}
+                className="w-full h-auto"
+              />
+            </div>
+          )}
+
+          {/* Article Body */}
+          <div className="prose prose-invert prose-lg max-w-none">
+            <div className="text-gray-300 leading-relaxed whitespace-pre-line">
+              {post.content}
+            </div>
+          </div>
+
+          {/* Share Section */}
+          <div className="mt-12 pt-12 border-t border-gray-800">
+            <h3 className="text-xl font-bold text-white mb-4">Share this article</h3>
+            <div className="flex flex-wrap gap-4">
+              <Button variant="outline">
+                Share on Twitter
+              </Button>
+              <Button variant="outline">
+                Share on Facebook
+              </Button>
+              <Button variant="outline">
+                Copy Link
+              </Button>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      {/* Related Posts */}
+      <section className="py-12 px-4 bg-dark-secondary">
+        <div className="max-w-4xl mx-auto">
+          <h2 className="text-2xl font-bold text-white mb-8">More from HLPFL</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            <Card className="p-6">
+              <span className="text-gold text-sm font-medium">Coming Soon</span>
+              <h3 className="text-lg font-bold text-white mt-2">More articles</h3>
+              <p className="text-gray-400 mt-2">We're working on more great content for you.</p>
+            </Card>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,8 +1,27 @@
 import { MetadataRoute } from 'next'
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://hlpfl.org'
+async function getBlogPosts() {
+  try {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000'}/api/blog/posts`)
+    const data = await response.json()
+    return data.success ? data.posts : []
+  } catch {
+    const { mockNews } = await import('@/data/mockData')
+    return mockNews
+  }
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://hlpfl.org'
   const currentDate = new Date().toISOString()
+  const posts = await getBlogPosts()
+
+  const postUrls = posts.map((post: any) => ({
+    url: `${baseUrl}/news/${post.slug}`,
+    lastModified: new Date(post.publishedAt),
+    changeFrequency: 'weekly' as const,
+    priority: 0.8,
+  }))
 
   return [
     {
@@ -38,8 +57,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     {
       url: `${baseUrl}/news`,
       lastModified: currentDate,
-      changeFrequency: 'weekly',
-      priority: 0.8,
+      changeFrequency: 'daily',
+      priority: 0.9,
     },
     {
       url: `${baseUrl}/submit-music`,
@@ -89,5 +108,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'yearly',
       priority: 0.3,
     },
+    ...postUrls,
   ]
 }


### PR DESCRIPTION
- Create API endpoint for blog posts (GET, POST, DELETE)
- Add individual blog post pages with SEO optimization
- Update news page to fetch from API with fallback to mockData
- Add dynamic sitemap generation for blog posts
- Improve loading states and error handling
- Add category filtering functionality
- Support both API and mockData for flexibility