### PR TITLE
Exclude functions directory from TypeScript ES5 target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "src/test/**/*", "vitest.config.ts"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "src/test/**/*", "vitest.config.ts", "functions/**/*"]
 }


### PR DESCRIPTION
The tsconfig.json was set to target ES5, which was causing Cloudflare to try transpiling the Pages Functions code. Functions should use modern JavaScript (ES2020+) and be handled by Cloudflare's build system independently of the Next.js TypeScript configuration.