### PR TITLE
Fix artist portal login and image paths

### DIFF
--- a/src/app/artist-portal/page.tsx
+++ b/src/app/artist-portal/page.tsx
@@ -21,9 +21,12 @@ export default function ArtistPortalLoginPage() {
     setError('')
 
     try {
+      // Note: In production, Cloudflare Pages Functions are at /api/auth/login
+      // During development with static export, this simulates the login
       const response = await fetch('/api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include', // Important for cookies
         body: JSON.stringify({ email, password })
       })
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { motion } from 'framer-motion'
 import {
   BarChart3,
@@ -21,10 +21,65 @@ import { useRouter } from 'next/navigation'
 
 export default function DashboardPage() {
   const router = useRouter()
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null)
+  const [user, setUser] = useState<any>(null)
 
-  const handleLogout = () => {
-    // TODO: Implement actual logout logic
-    router.push('/artist-portal')
+  useEffect(() => {
+    // Verify session on mount
+    const verifySession = async () => {
+      try {
+        const response = await fetch('/api/auth/verify', {
+          method: 'GET',
+          credentials: 'include'
+        })
+
+        const data = await response.json()
+
+        if (data.success && data.authenticated) {
+          setIsAuthenticated(true)
+          setUser(data.user)
+        } else {
+          setIsAuthenticated(false)
+          router.push('/artist-portal')
+        }
+      } catch (error) {
+        console.error('Session verification error:', error)
+        setIsAuthenticated(false)
+        router.push('/artist-portal')
+      }
+    }
+
+    verifySession()
+  }, [router])
+
+  const handleLogout = async () => {
+    try {
+      await fetch('/api/auth/login', {
+        method: 'DELETE',
+        credentials: 'include'
+      })
+    } catch (error) {
+      console.error('Logout error:', error)
+    } finally {
+      router.push('/artist-portal')
+    }
+  }
+
+  // Show loading while checking authentication
+  if (isAuthenticated === null) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-16 h-16 border-4 border-[#c87941] border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+          <p className="text-gray-400">Verifying session...</p>
+        </div>
+      </div>
+    )
+  }
+
+  // If not authenticated, show nothing (will redirect)
+  if (!isAuthenticated) {
+    return null
   }
 
   const tools = [

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -7,7 +7,7 @@ export const mockArtists: Artist[] = [
     slug: 'alki',
     bio: 'Boundary-pushing artist creating the future of alternative music. As HLPFL\'s first signed artist and co-founder, Alki embodies our revolutionary artist-first philosophy. With a unique blend of punk energy, pop sensibility, and rap lyricism, Alki is proving that independent artists can thrive with the right partnership. Known for explosive live performances and genre-defying sound. With nearly 48,000 monthly listeners and millions of streams, Alki is rapidly becoming a force in independent music.',
     genre: ['Punk', 'Pop', 'Rap'],
-    image: '/images/team/alki.jpg',
+    image: '/images/team/alki.webp',
     socials: {
       spotify: 'https://open.spotify.com/artist/1Jof1vMpSF5pIWUvG9cizl',
       instagram: 'https://www.instagram.com/alkiotis',
@@ -680,7 +680,7 @@ export const mockTeam: TeamMember[] = [
     name: 'James Rockel',
     role: 'Founder & CEO',
     bio: 'Founded HLPFL at 18 years old with a revolutionary vision for artist partnerships. James has transformed how independent musicians build sustainable careers through the groundbreaking 50/50 model. When not changing the music industry, he\'s discovering emerging talent at local shows.',
-    image: '/images/team/james-rockel.jpg',
+    image: '/images/team/james-rockel.webp',
     socials: {
       linkedin: '#',
       email: 'contact@hlpfl.org',
@@ -691,7 +691,7 @@ export const mockTeam: TeamMember[] = [
     name: 'Alki',
     role: 'Co-Founder & Signed Artist',
     bio: 'Boundary-pushing artist creating the future of alternative music. As HLPFL\'s first signed artist and co-founder, Alki embodies our revolutionary artist-first philosophy. With a unique blend of punk, pop, and rap, Alki is proving that independent artists can thrive with the right partnership. Nearly 48,000 monthly listeners and millions of streams.',
-    image: '/images/team/alki.jpg',
+    image: '/images/team/alki.webp',
     socials: {
       instagram: 'https://instagram.com/alkiotis',
       spotify: 'https://open.spotify.com/artist/1Jof1vMpSF5pIWUvG9cizl',
@@ -703,7 +703,7 @@ export const mockTeam: TeamMember[] = [
     name: 'Noah Rank',
     role: 'Director of Sales',
     bio: 'Leading HLPFL\'s sales strategy and business development initiatives. Noah brings expertise in music industry partnerships and revenue growth, helping artists maximize their commercial potential while maintaining creative integrity.',
-    image: '/images/team/noah-rank.jpg',
+    image: '/images/team/noah-rank.webp',
     socials: {
       linkedin: '#',
       email: 'noah@hlpfl.org',


### PR DESCRIPTION
- Added session verification to dashboard page with loading state
- Fixed logout to properly call DELETE endpoint
- Added credentials: 'include' to login fetch for cookie support
- Fixed Alki's profile image path from .jpg to .webp
- Fixed team member image paths (James Rockel, Noah Rank) to .webp
- Dashboard now redirects to login if not authenticated