### PR TITLE
Add facebook to Artist socials type definition

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,7 @@ export interface Artist {
     instagram?: string
     twitter?: string
     youtube?: string
+    facebook?: string
     website?: string
   }
 }


### PR DESCRIPTION
FIXES:
- Build error: facebook property not defined in Artist interface
- Added facebook?: string to socials object type

This allows Pardyalone's Facebook link to be properly typed.