### PR TITLE
Add album artwork update template for Alki and Pardyalone

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -14,7 +14,13 @@ npx wrangler d1 execute hlpfl-artist-portal --remote --file=database/schema.sql
 npx wrangler d1 execute hlpfl-artist-portal --remote --file=database/seed.sql
 ```
 
-## Adding Album Artwork from Spotify
+## Adding Artist Information and Album Artwork from Spotify
+
+### Quick Reference - Artist Spotify Pages
+
+- **Alki**: https://open.spotify.com/artist/0jIqPF7laDAaZmSeoSzLlt
+- **Priv**: Use the Spotify URL you have
+- **Pardyalone**: https://open.spotify.com/artist/6M4q5QWjmpjuPAi7LVFEFG
 
 ### Step 1: Get Spotify Image URLs
 
@@ -24,6 +30,18 @@ npx wrangler d1 execute hlpfl-artist-portal --remote --file=database/seed.sql
    - Right-click on the album artwork
    - Select **"Copy Image Address"** or **"Open Image in New Tab"**
    - The URL will look like: `https://i.scdn.co/image/ab67616d0000b273XXXXX`
+
+#### For Priv (Complete Artist Profile)
+1. Visit Priv's Spotify artist page
+2. Use the dedicated template: `database/priv-data.sql`
+3. This file includes:
+   - Complete artist profile (bio, avatar, all social media)
+   - All releases with full metadata
+   - Streaming platform URLs
+   - Analytics data templates
+   - Individual track listings for EPs/albums
+4. Fill in ALL placeholders in the file
+5. Run: `npx wrangler d1 execute hlpfl-artist-portal --file=database/priv-data.sql`
 
 #### For Pardyalone
 1. Visit: https://open.spotify.com/artist/6M4q5QWjmpjuPAi7LVFEFG
@@ -89,7 +107,9 @@ getArtistAlbums('6M4q5QWjmpjuPAi7LVFEFG');
 
 - **schema.sql** - Complete database schema (25+ tables)
 - **seed.sql** - Sample data for development
-- **update-artwork.sql** - Template for adding album artwork URLs
+- **update-artwork.sql** - Quick template for adding album artwork URLs
+- **priv-data.sql** - Comprehensive template for all Priv artist data (profile + discography)
+- **README.md** - This file - database management guide
 
 ## Helpful Commands
 

--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,111 @@
+# Database Management Guide
+
+## Quick Start
+
+### Initialize Database
+
+```bash
+# Local database
+npx wrangler d1 execute hlpfl-artist-portal --file=database/schema.sql
+npx wrangler d1 execute hlpfl-artist-portal --file=database/seed.sql
+
+# Remote/Production database
+npx wrangler d1 execute hlpfl-artist-portal --remote --file=database/schema.sql
+npx wrangler d1 execute hlpfl-artist-portal --remote --file=database/seed.sql
+```
+
+## Adding Album Artwork from Spotify
+
+### Step 1: Get Spotify Image URLs
+
+#### For Alki
+1. Visit: https://open.spotify.com/artist/0jIqPF7laDAaZmSeoSzLlt
+2. For each release (Switched Up, 221, Late Nights, etc.):
+   - Right-click on the album artwork
+   - Select **"Copy Image Address"** or **"Open Image in New Tab"**
+   - The URL will look like: `https://i.scdn.co/image/ab67616d0000b273XXXXX`
+
+#### For Pardyalone
+1. Visit: https://open.spotify.com/artist/6M4q5QWjmpjuPAi7LVFEFG
+2. Copy image URLs for all releases/albums
+3. Note the release titles, dates, and track URLs
+
+### Step 2: Update the SQL File
+
+Edit `database/update-artwork.sql`:
+
+```sql
+-- Replace the placeholder text with actual URLs
+UPDATE releases
+SET cover_art_url = 'https://i.scdn.co/image/ab67616d0000b273ACTUAL_IMAGE_ID'
+WHERE id = 'release-switched-up';
+```
+
+### Step 3: Run the Update
+
+```bash
+# Local database
+npx wrangler d1 execute hlpfl-artist-portal --file=database/update-artwork.sql
+
+# Remote database
+npx wrangler d1 execute hlpfl-artist-portal --remote --file=database/update-artwork.sql
+```
+
+## Alternative: Using Spotify API
+
+If you want to automate this process:
+
+```javascript
+// Example using Spotify Web API
+const getArtistAlbums = async (artistId) => {
+  const response = await fetch(
+    `https://api.spotify.com/v1/artists/${artistId}/albums`,
+    {
+      headers: {
+        'Authorization': `Bearer YOUR_SPOTIFY_TOKEN`
+      }
+    }
+  );
+  const data = await response.json();
+
+  data.items.forEach(album => {
+    console.log({
+      name: album.name,
+      artwork: album.images[0].url,  // 640x640
+      releaseDate: album.release_date,
+      spotifyUrl: album.external_urls.spotify
+    });
+  });
+};
+
+// Alki
+getArtistAlbums('0jIqPF7laDAaZmSeoSzLlt');
+
+// Pardyalone
+getArtistAlbums('6M4q5QWjmpjuPAi7LVFEFG');
+```
+
+## Database Files
+
+- **schema.sql** - Complete database schema (25+ tables)
+- **seed.sql** - Sample data for development
+- **update-artwork.sql** - Template for adding album artwork URLs
+
+## Helpful Commands
+
+```bash
+# Query the database
+npx wrangler d1 execute hlpfl-artist-portal --command "SELECT * FROM releases"
+
+# Backup database
+npx wrangler d1 export hlpfl-artist-portal --output backup.sql
+
+# Check database info
+npx wrangler d1 info hlpfl-artist-portal
+```
+
+## Spotify Resources
+
+- [Pardyalone on Spotify](https://open.spotify.com/artist/6M4q5QWjmpjuPAi7LVFEFG)
+- [Spotify for Artists](https://artists.spotify.com)
+- [Spotify Album Artwork Downloader](https://spotisongdownloader.com/spotify-artwork-downloader/)

--- a/database/priv-data.sql
+++ b/database/priv-data.sql
@@ -1,0 +1,267 @@
+-- ============================================================================
+-- PRIV - Complete Artist Profile and Discography
+-- ============================================================================
+--
+-- This file contains all information for artist Priv
+-- Fill in the placeholders with actual data from Spotify
+--
+-- Instructions:
+-- 1. Visit Priv's Spotify artist page
+-- 2. Copy all release information (titles, dates, artwork URLs)
+-- 3. Replace ALL_CAPS placeholders below
+-- 4. Run: npx wrangler d1 execute hlpfl-artist-portal --file=database/priv-data.sql
+-- ============================================================================
+
+-- ============================================================================
+-- ARTIST PROFILE
+-- ============================================================================
+
+UPDATE profiles
+SET
+    -- Basic Info
+    artist_name = 'Priv',
+    display_name = 'Priv',
+    bio = 'PASTE_PRIV_BIO_HERE',
+
+    -- Profile Images
+    avatar_url = 'PASTE_PRIV_PROFILE_IMAGE_URL_HERE',
+
+    -- Streaming Platforms
+    spotify_url = 'PASTE_PRIV_SPOTIFY_ARTIST_URL_HERE',
+    apple_music_url = 'PASTE_PRIV_APPLE_MUSIC_URL_HERE',
+    youtube_url = 'PASTE_PRIV_YOUTUBE_CHANNEL_URL_HERE',
+    soundcloud_url = 'PASTE_PRIV_SOUNDCLOUD_URL_HERE',
+    tidal_url = 'PASTE_PRIV_TIDAL_URL_HERE',
+
+    -- Social Media
+    instagram_handle = '@PRIV_INSTAGRAM',
+    twitter_handle = '@PRIV_TWITTER',
+    tiktok_handle = '@PRIV_TIKTOK',
+
+    -- Other Info
+    location = 'CITY, STATE',
+    website = 'https://PRIV_WEBSITE_URL'
+WHERE id = 'artist-priv-001';
+
+-- ============================================================================
+-- RELEASES / DISCOGRAPHY
+-- ============================================================================
+-- Add all of Priv's releases below
+-- Copy this template for each release
+
+-- RELEASE 1
+-- ----------------------------------------------------------------------------
+INSERT OR REPLACE INTO releases (
+    id,
+    artist_id,
+    title,
+    slug,
+    release_type,
+    release_date,
+    cover_art_url,
+    description,
+    genre,
+    spotify_url,
+    apple_music_url,
+    youtube_url,
+    soundcloud_url,
+    tidal_url,
+    amazon_music_url,
+    status,
+    total_streams,
+    total_listeners,
+    presaves
+) VALUES (
+    'release-priv-001',
+    'artist-priv-001',
+    'RELEASE_TITLE_1',                    -- e.g., "Midnight Drive"
+    'release-slug-1',                      -- e.g., "midnight-drive" (lowercase, hyphenated)
+    'single',                              -- 'single', 'ep', or 'album'
+    '2025-XX-XX',                          -- Release date (YYYY-MM-DD)
+    'PASTE_ARTWORK_URL_1',                 -- Album artwork URL from Spotify
+    'PASTE_DESCRIPTION_HERE',              -- Brief description of the release
+    'Alternative/Indie',                   -- Genre(s)
+    'PASTE_SPOTIFY_TRACK_URL_1',          -- Full Spotify track/album URL
+    'PASTE_APPLE_MUSIC_URL_1',            -- Apple Music URL
+    'PASTE_YOUTUBE_URL_1',                -- YouTube Music/Video URL
+    'PASTE_SOUNDCLOUD_URL_1',             -- SoundCloud URL (if available)
+    'PASTE_TIDAL_URL_1',                  -- Tidal URL (if available)
+    'PASTE_AMAZON_MUSIC_URL_1',           -- Amazon Music URL (if available)
+    'live',                                -- 'draft', 'scheduled', 'live', or 'archived'
+    0,                                     -- Total streams (update with real number)
+    0,                                     -- Total listeners (update with real number)
+    0                                      -- Presaves (if applicable)
+);
+
+-- RELEASE 2
+-- ----------------------------------------------------------------------------
+INSERT OR REPLACE INTO releases (
+    id,
+    artist_id,
+    title,
+    slug,
+    release_type,
+    release_date,
+    cover_art_url,
+    description,
+    genre,
+    spotify_url,
+    apple_music_url,
+    youtube_url,
+    soundcloud_url,
+    tidal_url,
+    amazon_music_url,
+    status,
+    total_streams,
+    total_listeners,
+    presaves
+) VALUES (
+    'release-priv-002',
+    'artist-priv-001',
+    'RELEASE_TITLE_2',
+    'release-slug-2',
+    'single',
+    '2025-XX-XX',
+    'PASTE_ARTWORK_URL_2',
+    'PASTE_DESCRIPTION_HERE',
+    'Alternative/Indie',
+    'PASTE_SPOTIFY_TRACK_URL_2',
+    'PASTE_APPLE_MUSIC_URL_2',
+    'PASTE_YOUTUBE_URL_2',
+    'PASTE_SOUNDCLOUD_URL_2',
+    'PASTE_TIDAL_URL_2',
+    'PASTE_AMAZON_MUSIC_URL_2',
+    'live',
+    0,
+    0,
+    0
+);
+
+-- RELEASE 3
+-- ----------------------------------------------------------------------------
+INSERT OR REPLACE INTO releases (
+    id,
+    artist_id,
+    title,
+    slug,
+    release_type,
+    release_date,
+    cover_art_url,
+    description,
+    genre,
+    spotify_url,
+    apple_music_url,
+    youtube_url,
+    soundcloud_url,
+    tidal_url,
+    amazon_music_url,
+    status,
+    total_streams,
+    total_listeners,
+    presaves
+) VALUES (
+    'release-priv-003',
+    'artist-priv-001',
+    'RELEASE_TITLE_3',
+    'release-slug-3',
+    'ep',
+    '2026-XX-XX',
+    'PASTE_ARTWORK_URL_3',
+    'PASTE_DESCRIPTION_HERE',
+    'Alternative/Indie',
+    'PASTE_SPOTIFY_ALBUM_URL_3',
+    'PASTE_APPLE_MUSIC_URL_3',
+    'PASTE_YOUTUBE_URL_3',
+    'PASTE_SOUNDCLOUD_URL_3',
+    'PASTE_TIDAL_URL_3',
+    'PASTE_AMAZON_MUSIC_URL_3',
+    'scheduled',
+    0,
+    0,
+    0
+);
+
+-- ADD MORE RELEASES HERE
+-- Copy the template above and increment the ID: release-priv-004, release-priv-005, etc.
+
+-- ============================================================================
+-- TRACKS (Optional - for EPs and Albums)
+-- ============================================================================
+-- If adding an EP or Album, list individual tracks here
+
+-- Example for EP/Album tracks:
+/*
+INSERT OR REPLACE INTO tracks (
+    id,
+    release_id,
+    title,
+    track_number,
+    duration,
+    isrc,
+    spotify_url,
+    apple_music_url
+) VALUES
+('track-priv-ep-001', 'release-priv-003', 'Track 1 Title', 1, 180, 'PASTE_ISRC', 'PASTE_SPOTIFY_URL', 'PASTE_APPLE_URL'),
+('track-priv-ep-002', 'release-priv-003', 'Track 2 Title', 2, 195, 'PASTE_ISRC', 'PASTE_SPOTIFY_URL', 'PASTE_APPLE_URL'),
+('track-priv-ep-003', 'release-priv-003', 'Track 3 Title', 3, 210, 'PASTE_ISRC', 'PASTE_SPOTIFY_URL', 'PASTE_APPLE_URL');
+*/
+
+-- ============================================================================
+-- ANALYTICS DATA (Optional - for realistic dashboard)
+-- ============================================================================
+-- Add streaming analytics for the last 30 days
+
+/*
+INSERT OR REPLACE INTO analytics_streams (id, artist_id, release_id, date, platform, streams, listeners, saves, shares) VALUES
+('analytics-priv-001', 'artist-priv-001', 'release-priv-001', '2026-01-08', 'spotify', 0, 0, 0, 0),
+('analytics-priv-002', 'artist-priv-001', 'release-priv-001', '2026-01-07', 'spotify', 0, 0, 0, 0),
+('analytics-priv-003', 'artist-priv-001', 'release-priv-002', '2026-01-08', 'spotify', 0, 0, 0, 0);
+*/
+
+-- ============================================================================
+-- SOCIAL MEDIA ACCOUNTS (Optional)
+-- ============================================================================
+
+/*
+INSERT OR REPLACE INTO social_accounts (
+    id,
+    artist_id,
+    platform,
+    username,
+    url,
+    followers,
+    is_connected,
+    access_token_expires
+) VALUES
+('social-priv-instagram', 'artist-priv-001', 'instagram', '@PRIV_INSTAGRAM', 'https://instagram.com/PRIV_INSTAGRAM', 0, 0, NULL),
+('social-priv-twitter', 'artist-priv-001', 'twitter', '@PRIV_TWITTER', 'https://twitter.com/PRIV_TWITTER', 0, 0, NULL),
+('social-priv-tiktok', 'artist-priv-001', 'tiktok', '@PRIV_TIKTOK', 'https://tiktok.com/@PRIV_TIKTOK', 0, 0, NULL);
+*/
+
+-- ============================================================================
+-- NOTES
+-- ============================================================================
+--
+-- How to get Spotify artwork URLs:
+-- 1. Open Priv's Spotify page in browser
+-- 2. Right-click album artwork → "Copy Image Address"
+-- 3. URL format: https://i.scdn.co/image/ab67616d0000b273XXXXX
+--
+-- Slug naming convention:
+-- - Lowercase only
+-- - Replace spaces with hyphens
+-- - Remove special characters
+-- - Example: "Summer Vibes!" → "summer-vibes"
+--
+-- Release types:
+-- - 'single' - 1-2 tracks
+-- - 'ep' - 3-6 tracks
+-- - 'album' - 7+ tracks
+--
+-- Status options:
+-- - 'draft' - Not yet released, work in progress
+-- - 'scheduled' - Release date set, waiting to go live
+-- - 'live' - Currently released and available
+-- - 'archived' - Older release, still available but not actively promoted
+--
+-- ============================================================================

--- a/database/update-artwork.sql
+++ b/database/update-artwork.sql
@@ -37,6 +37,133 @@ SET avatar_url = 'PASTE_ALKI_PROFILE_IMAGE_URL_HERE',
 WHERE id = 'artist-alki-001';
 
 -- ============================================================================
+-- PRIV - Complete Artist Information
+-- Spotify Artist: PASTE_PRIV_SPOTIFY_ARTIST_URL_HERE
+-- ============================================================================
+
+-- Update Priv artist profile with complete information
+UPDATE profiles
+SET
+    avatar_url = 'PASTE_PRIV_PROFILE_IMAGE_URL_HERE',
+    bio = 'PASTE_PRIV_BIO_HERE',
+    spotify_url = 'PASTE_PRIV_SPOTIFY_URL_HERE',
+    apple_music_url = 'PASTE_PRIV_APPLE_MUSIC_URL_HERE',
+    instagram_handle = '@PRIV_INSTAGRAM_HANDLE',
+    twitter_handle = '@PRIV_TWITTER_HANDLE',
+    tiktok_handle = '@PRIV_TIKTOK_HANDLE',
+    youtube_url = 'PASTE_PRIV_YOUTUBE_URL_HERE'
+WHERE id = 'artist-priv-001';
+
+-- Add/Update Priv releases
+-- Release 1
+INSERT OR REPLACE INTO releases (
+    id,
+    artist_id,
+    title,
+    slug,
+    release_type,
+    release_date,
+    cover_art_url,
+    description,
+    genre,
+    spotify_url,
+    apple_music_url,
+    youtube_url,
+    status,
+    total_streams,
+    total_listeners
+) VALUES (
+    'release-priv-001',
+    'artist-priv-001',
+    'RELEASE_TITLE_1',
+    'release-slug-1',
+    'single',  -- or 'ep' or 'album'
+    '2025-XX-XX',
+    'PASTE_ARTWORK_URL_1',
+    'PASTE_DESCRIPTION_HERE',
+    'Alternative/Indie',
+    'PASTE_SPOTIFY_TRACK_URL_1',
+    'PASTE_APPLE_MUSIC_URL_1',
+    'PASTE_YOUTUBE_URL_1',
+    'live',  -- or 'scheduled' or 'draft'
+    0,  -- update with actual stream count
+    0   -- update with actual listener count
+);
+
+-- Release 2
+INSERT OR REPLACE INTO releases (
+    id,
+    artist_id,
+    title,
+    slug,
+    release_type,
+    release_date,
+    cover_art_url,
+    description,
+    genre,
+    spotify_url,
+    apple_music_url,
+    youtube_url,
+    status,
+    total_streams,
+    total_listeners
+) VALUES (
+    'release-priv-002',
+    'artist-priv-001',
+    'RELEASE_TITLE_2',
+    'release-slug-2',
+    'single',
+    '2025-XX-XX',
+    'PASTE_ARTWORK_URL_2',
+    'PASTE_DESCRIPTION_HERE',
+    'Alternative/Indie',
+    'PASTE_SPOTIFY_TRACK_URL_2',
+    'PASTE_APPLE_MUSIC_URL_2',
+    'PASTE_YOUTUBE_URL_2',
+    'live',
+    0,
+    0
+);
+
+-- Release 3
+INSERT OR REPLACE INTO releases (
+    id,
+    artist_id,
+    title,
+    slug,
+    release_type,
+    release_date,
+    cover_art_url,
+    description,
+    genre,
+    spotify_url,
+    apple_music_url,
+    youtube_url,
+    status,
+    total_streams,
+    total_listeners
+) VALUES (
+    'release-priv-003',
+    'artist-priv-001',
+    'RELEASE_TITLE_3',
+    'release-slug-3',
+    'ep',
+    '2025-XX-XX',
+    'PASTE_ARTWORK_URL_3',
+    'PASTE_DESCRIPTION_HERE',
+    'Alternative/Indie',
+    'PASTE_SPOTIFY_ALBUM_URL_3',
+    'PASTE_APPLE_MUSIC_URL_3',
+    'PASTE_YOUTUBE_URL_3',
+    'live',
+    0,
+    0
+);
+
+-- Add more releases as needed by copying the template above
+-- Just increment the ID: release-priv-004, release-priv-005, etc.
+
+-- ============================================================================
 -- PARDYALONE - Album Artwork
 -- Spotify Artist: https://open.spotify.com/artist/6M4q5QWjmpjuPAi7LVFEFG
 -- ============================================================================

--- a/database/update-artwork.sql
+++ b/database/update-artwork.sql
@@ -1,0 +1,78 @@
+-- Update Album Artwork URLs from Spotify
+-- Instructions: Replace the placeholder URLs with actual Spotify album artwork URLs
+-- To get Spotify artwork URLs:
+--   1. Visit the artist page on Spotify
+--   2. Right-click on album artwork and "Copy Image Address"
+--   3. Paste the URL below
+
+-- ============================================================================
+-- ALKI - Album Artwork
+-- Spotify Artist: https://open.spotify.com/artist/0jIqPF7laDAaZmSeoSzLlt
+-- ============================================================================
+
+-- "Switched Up" single
+UPDATE releases
+SET cover_art_url = 'PASTE_SWITCHED_UP_ARTWORK_URL_HERE'
+WHERE id = 'release-switched-up';
+
+-- "221" single
+UPDATE releases
+SET cover_art_url = 'PASTE_221_ARTWORK_URL_HERE'
+WHERE id = 'release-221';
+
+-- "Late Nights" single
+UPDATE releases
+SET cover_art_url = 'PASTE_LATE_NIGHTS_ARTWORK_URL_HERE'
+WHERE id = 'release-late-nights';
+
+-- "Midnight Dreams" single (upcoming)
+UPDATE releases
+SET cover_art_url = 'PASTE_MIDNIGHT_DREAMS_ARTWORK_URL_HERE'
+WHERE id = 'release-midnight-dreams';
+
+-- Update Alki artist profile avatar
+UPDATE profiles
+SET avatar_url = 'PASTE_ALKI_PROFILE_IMAGE_URL_HERE',
+    spotify_url = 'https://open.spotify.com/artist/0jIqPF7laDAaZmSeoSzLlt'
+WHERE id = 'artist-alki-001';
+
+-- ============================================================================
+-- PARDYALONE - Album Artwork
+-- Spotify Artist: https://open.spotify.com/artist/6M4q5QWjmpjuPAi7LVFEFG
+-- ============================================================================
+
+-- Add Pardyalone releases (customize with actual release data)
+INSERT OR REPLACE INTO releases (id, artist_id, title, slug, release_type, release_date, cover_art_url, status, total_streams, total_listeners, genre, spotify_url) VALUES
+('release-pardy-001', 'artist-pardyalone-001', 'RELEASE_TITLE_1', 'release-slug-1', 'single', '2025-XX-XX', 'PASTE_ARTWORK_URL_1', 'live', 0, 0, 'Alternative', 'PASTE_SPOTIFY_TRACK_URL_1'),
+('release-pardy-002', 'artist-pardyalone-001', 'RELEASE_TITLE_2', 'release-slug-2', 'single', '2025-XX-XX', 'PASTE_ARTWORK_URL_2', 'live', 0, 0, 'Alternative', 'PASTE_SPOTIFY_TRACK_URL_2'),
+('release-pardy-003', 'artist-pardyalone-001', 'RELEASE_TITLE_3', 'release-slug-3', 'album', '2025-XX-XX', 'PASTE_ARTWORK_URL_3', 'live', 0, 0, 'Alternative', 'PASTE_SPOTIFY_ALBUM_URL_3');
+
+-- Update Pardyalone artist profile
+UPDATE profiles
+SET avatar_url = 'PASTE_PARDYALONE_PROFILE_IMAGE_URL_HERE',
+    spotify_url = 'https://open.spotify.com/artist/6M4q5QWjmpjuPAi7LVFEFG'
+WHERE id = 'artist-pardyalone-001';
+
+-- ============================================================================
+-- HOW TO GET SPOTIFY IMAGE URLS:
+-- ============================================================================
+--
+-- Method 1: Right-click on Spotify Web Player
+--   1. Open artist page in browser
+--   2. Right-click on album artwork
+--   3. Select "Copy Image Address" or "Open Image in New Tab"
+--   4. The URL will look like: https://i.scdn.co/image/ab67616d0000b273XXXXX
+--
+-- Method 2: Use Spotify API (for developers)
+--   - Get artist albums: GET /v1/artists/{id}/albums
+--   - Album images are in the response: albums.items[].images[]
+--
+-- Method 3: Use third-party tools
+--   - spotisongdownloader.com/spotify-artwork-downloader/
+--   - albumcoverdownloader.com
+--
+-- ============================================================================
+
+-- After updating the URLs above, run this file:
+-- npx wrangler d1 execute hlpfl-artist-portal --file=database/update-artwork.sql
+-- For remote: npx wrangler d1 execute hlpfl-artist-portal --remote --file=database/update-artwork.sql


### PR DESCRIPTION
Created tools to help add real Spotify album artwork:

Files Added:
- database/update-artwork.sql - SQL template for updating release artwork
  * Alki releases: Switched Up, 221, Late Nights, Midnight Dreams
  * Pardyalone releases: Template for adding multiple releases
  * Profile avatars for both artists
  * Includes Spotify artist URLs

- database/README.md - Database management guide
  * Instructions for getting Spotify image URLs
  * Step-by-step artwork update process
  * Alternative Spotify API approach for automation
  * Helpful database commands

Usage:
1. Visit Alki: https://open.spotify.com/artist/0jIqPF7laDAaZmSeoSzLlt
2. Visit Pardyalone: https://open.spotify.com/artist/6M4q5QWjmpjuPAi7LVFEFG
3. Right-click album artwork and copy image URLs
4. Update database/update-artwork.sql with actual URLs
5. Run: npx wrangler d1 execute hlpfl-artist-portal --file=database/update-artwork.sql