### PR TITLE
Fix TypeScript error in community page API call

### DIFF
--- a/src/app/dashboard/community/page.tsx
+++ b/src/app/dashboard/community/page.tsx
@@ -56,7 +56,7 @@ export default function CommunityFeed() {
     async function loadCommunity() {
       try {
         setLoading(true)
-        const response = await api.community.getPosts({ artistId })
+        const response = await api.community.getPosts(artistId)
 
         if (response.success && response.data) {
           setCommunityData(response.data)


### PR DESCRIPTION
- Change api.community.getPosts({ artistId }) to api.community.getPosts(artistId)
- The API expects artistId string as first parameter, not an object
- Fixes Cloudflare build error