### PR TITLE
Major update: Remove Alki from platform and make PRIV the main artist

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -43,7 +43,7 @@ export default function AboutPage() {
   ]
 
   const stats = [
-    { number: '5', label: 'Artists' },
+    { number: '4', label: 'Artists' },
     { number: '50+', label: 'Releases' },
     { number: '63m+', label: 'Streams' },
     { number: '7', label: 'Years' }
@@ -58,8 +58,8 @@ export default function AboutPage() {
             About <span className="text-gold">HLPFL</span>
           </h1>
           <p className="text-xl text-gray-300 mb-8 leading-relaxed">
-            Founded by James Rockel at just 18 years old, HLPFL is revolutionizing the music industry with artist-first partnerships. 
-            With boundary-pushing artist Alki as co-founder, we're proving that independent artists can thrive with our groundbreaking 50/50 model and genuine support.
+            Founded by James Rockel at just 18 years old, HLPFL is revolutionizing the music industry with artist-first partnerships.
+            We're proving that independent artists can thrive with our groundbreaking 50/50 model and genuine support.
           </p>
         </div>
       </section>
@@ -92,15 +92,15 @@ export default function AboutPage() {
               </h2>
               <div className="space-y-4 text-gray-300">
                 <p className="leading-relaxed">
-                  Founded in 2019, HLPFL began when James Rockel, just 18 years old, witnessed countless talented musicians struggle with outdated industry practices. 
+                  Founded in 2019, HLPFL began when James Rockel, just 18 years old, witnessed countless talented musicians struggle with outdated industry practices.
                   James envisioned a new paradigm where artists keep control of their music and earn fair revenue.
                 </p>
                 <p className="leading-relaxed">
-                  The vision became reality when Alki (@alkiotis), a boundary-pushing artist creating the future of rock music, joined as both signed artist and co-founder. 
-                  Together, they proved the revolutionary 50/50 partnership model works, building a foundation for how modern music careers should function.
+                  The vision became reality with the revolutionary 50/50 partnership model, building a foundation for how modern music careers should function.
+                  By signing talented artists like Pardyalone, Priv, Writ3rs Block, and Adam Rodway, we've proven that this model works.
                 </p>
                 <p className="leading-relaxed">
-                  Today, from our Grand Rapids headquarters, HLPFL continues to transform the industry one artist at a time, 
+                  Today, from our Grand Rapids headquarters, HLPFL continues to transform the industry one artist at a time,
                   proving that independence, artistic integrity, and commercial success can coexist in the modern music landscape.
                 </p>
               </div>
@@ -156,11 +156,6 @@ export default function AboutPage() {
                 icon: Award,
                 title: 'Analytics Dashboard',
                 description: 'Track your growth, understand your audience, and make data-driven decisions.',
-              },
-              {
-                icon: Heart,
-                title: 'Alki Music Vault',
-                description: 'Exclusive access to 300+ unreleased songs for remix and collaboration.',
               },
             ].map((tool) => {
               const Icon = tool.icon

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -133,9 +133,8 @@ export default function ContactPage() {
             Get in <span className="text-gold">Touch</span>
           </h1>
           <p className="text-xl text-gray-300 mb-8">
-            Founded by James Rockel at 18 and powered by co-founder Alki's boundary-pushing artistry,
-            we're redefining music industry partnerships. Whether you're interested in our revolutionary 50/50 partnership model,
-            want to join the movement, or have questions about artist success, we're here to help.
+            Founded by James Rockel at 18, we're redefining music industry partnerships with our revolutionary 50/50 partnership model.
+            Whether you're interested in joining the movement or have questions about artist success, we're here to help.
           </p>
         </div>
       </section>

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -6,16 +6,15 @@ import { Artist, Release, NewsPost, TeamMember } from '@/types'
 export const mockArtists: Artist[] = [
   {
     id: '1',
-    name: 'Alki',
-    slug: 'alki',
-    bio: 'Alkiviadis Halkiotis, known professionally as Alki, blends punk energy, pop hooks, and raw rap delivery into a sound that defies easy categorization. With nearly 46,000 monthly listeners on Spotify and millions of streams across platforms, Alki has built a devoted following through relentlessly honest storytelling and genre-bending production.\n\nAs Co-Founder of HLPFL, Alki represents everything the label stands for: artist ownership, creative freedom, and authentic connection with fans. His catalog includes 37+ released recordings with over 300 unreleased tracks ready to drop.\n\nTop tracks like "Switched Up" (3M+ streams), "Too Much" (1.1M+ streams), and "Deceiving" (810K+ streams) showcase his ability to merge vulnerability with undeniable hooks.',
-    genre: ['Punk', 'Pop', 'Rap', 'Alternative'],
-    image: '/images/team/alki.webp',
+    name: 'Priv',
+    slug: 'priv',
+    bio: 'Priv is an emerging artist bringing a fresh perspective to the HLPFL roster. With a unique sound that blends innovation and authenticity, Priv represents the next generation of independent music. As part of the HLPFL family, Priv maintains complete creative control and ownership while accessing the tools and support needed to build a sustainable music career.\n\n"I\'ve been making music my whole life, but I\'ve never felt truly free until now. HLPFL gets it. They understand that the best art comes from artists who aren\'t afraid to experiment, fail, and try again. No pressure to fit a mold—just pure creation." - Priv\n\nStay tuned for upcoming releases and performances from this exciting new talent.',
+    genre: ['Alternative', 'Indie', 'Experimental'],
+    image: '',
     socials: {
-      spotify: 'https://open.spotify.com/artist/1Jof1vMpSF5pIWUvG9cizl',
-      instagram: 'https://www.instagram.com/alkiotis',
-      twitter: 'https://twitter.com/alkiotis',
-      website: 'https://app.grouped.com/everythingalki',
+      spotify: '',
+      instagram: '',
+      twitter: '',
     },
   },
   {
@@ -35,19 +34,6 @@ export const mockArtists: Artist[] = [
   },
   {
     id: '3',
-    name: 'Priv',
-    slug: 'priv',
-    bio: 'Priv is an emerging artist bringing a fresh perspective to the HLPFL roster. With a unique sound that blends innovation and authenticity, Priv represents the next generation of independent music. As part of the HLPFL family, Priv maintains complete creative control and ownership while accessing the tools and support needed to build a sustainable music career.\n\n"I\'ve been making music my whole life, but I\'ve never felt truly free until now. HLPFL gets it. They understand that the best art comes from artists who aren\'t afraid to experiment, fail, and try again. No pressure to fit a mold—just pure creation." - Priv\n\nStay tuned for upcoming releases and performances from this exciting new talent.',
-    genre: ['Alternative', 'Indie', 'Experimental'],
-    image: '',
-    socials: {
-      spotify: '',
-      instagram: '',
-      twitter: '',
-    },
-  },
-  {
-    id: '4',
     name: 'Writ3rs Block',
     slug: 'writ3rs-block',
     bio: 'Writ3rs Block is a music collective pushing the boundaries of alternative and experimental sounds. Their 2023 release "Too Much To Dream (The Chocolate Shop Demos)" showcases their unique blend of psychedelic influences, indie sensibilities, and innovative production.\n\nThe group\'s collaborative approach brings together diverse talents including songwriters Blane Conant, Olivia Zoe Johnson, and Brandon Skeen. With tracks like "Love (That\'s What They Call It)," "Garden," and "Lonesome Dove," Writ3rs Block creates atmospheric soundscapes that transport listeners to new sonic territories.\n\nSigned to HLPFL under the revolutionary 50/50 partnership model, Writ3rs Block maintains complete creative control while accessing professional support for distribution and promotion.',
@@ -59,7 +45,7 @@ export const mockArtists: Artist[] = [
     },
   },
   {
-    id: '5',
+    id: '4',
     name: 'Adam Rodway',
     slug: 'adam-rodway',
     bio: 'Adam Rodway is a rising Pop/Rock artist from Toronto, known for his introspective yet catchy sound that resonates with anyone who\'s faced the trials of a breakup. Recently, Adam collaborated with producer Matt Snell (Dua Lipa, The Glorious Sons, Dermot Kennedy) and Danny Lopez (Harm & Ease), adding a polished intensity to his raw style.\n\nFeatured on Hockey Night In Canada with his single "Too Long To Type," Adam has quickly become an iHeartRadio Future Star. His catalog includes popular tracks like "Tarantino," "Too Late," "The Garden Song," and "Hold Just Anyone."\n\nWith a sound that blends pop sensibility with rock edge, Adam Rodway brings emotional honesty and infectious melodies to the HLPFL roster.',
@@ -72,242 +58,6 @@ export const mockArtists: Artist[] = [
   },
 ]
 
-// ========================================
-// ALKI RELEASES
-// ========================================
-const alkiReleases: Release[] = [
-  // === 2025 RELEASES ===
-  {
-    id: 'alki-1',
-    title: '221',
-    artist: 'Alki',
-    artistId: '1',
-    type: 'single',
-    releaseDate: new Date('2025-01-17'),
-    coverArt: '/images/releases/221.png',
-    description: 'The latest single from Alki, showcasing his evolution as an artist with fresh production and raw lyricism. Angsty and punchy rap record that screams, "I hate you".',
-    links: {
-      spotify: 'https://open.spotify.com/album/468FaHLWX75g0RJdoEUABD',
-      apple: 'https://music.apple.com/album/221-single/1853361772',
-      youtube: 'https://www.youtube.com/watch?v=221',
-    },
-    tracks: [
-      { id: '1', title: '221', duration: '1:49' },
-    ],
-  },
-  {
-    id: 'alki-2',
-    title: 'Lackin',
-    artist: 'Alki',
-    artistId: '1',
-    type: 'single',
-    releaseDate: new Date('2025-01-10'),
-    coverArt: '/images/releases/lackin.jpg',
-    description: 'A high-energy track about staying focused and not falling behind.',
-    links: {
-      spotify: 'https://open.spotify.com/album/5QHzjA4cUCRDOPwWpNosXt',
-      apple: 'https://music.apple.com/album/lackin',
-    },
-    tracks: [
-      { id: '1', title: 'Lackin', duration: '1:42' },
-    ],
-  },
-  {
-    id: 'alki-3',
-    title: 'No Service',
-    artist: 'Alki',
-    artistId: '1',
-    type: 'single',
-    releaseDate: new Date('2024-12-20'),
-    coverArt: '/images/releases/no-service.jpg',
-    description: 'Disconnection and isolation themes explored through punchy production.',
-    links: {
-      spotify: 'https://open.spotify.com/album/5KZ4e4dQ5vt2sUo7XBmxyQ',
-      apple: 'https://music.apple.com/album/no-service',
-    },
-    tracks: [
-      { id: '1', title: 'No Service', duration: '1:59' },
-    ],
-  },
-
-  // === 2024 RELEASES ===
-  {
-    id: 'alki-4',
-    title: 'Get Down',
-    artist: 'Alki',
-    artistId: '1',
-    type: 'single',
-    releaseDate: new Date('2024-11-15'),
-    coverArt: '/images/releases/get-down.jpg',
-    description: 'An infectious dance-ready track with Alki\'s signature style.',
-    links: {
-      spotify: 'https://open.spotify.com/album/2AWKJ7CFAnTbxZUNjnuO3G',
-      apple: 'https://music.apple.com/album/get-down',
-    },
-    tracks: [
-      { id: '1', title: 'Get Down', duration: '1:37' },
-    ],
-  },
-  {
-    id: 'alki-5',
-    title: 'Better Off',
-    artist: 'Alki',
-    artistId: '1',
-    type: 'single',
-    releaseDate: new Date('2024-10-25'),
-    coverArt: '/images/releases/better-off.jpg',
-    description: 'A reflective track about growth and moving forward.',
-    links: {
-      spotify: 'https://open.spotify.com/album/4kOzmQpzk7lDtIiH7n6sXZ',
-      apple: 'https://music.apple.com/album/better-off',
-    },
-    tracks: [
-      { id: '1', title: 'Better Off', duration: '2:14' },
-    ],
-  },
-  {
-    id: 'alki-6',
-    title: 'Boujee Bish',
-    artist: 'Alki',
-    artistId: '1',
-    type: 'single',
-    releaseDate: new Date('2024-09-20'),
-    coverArt: '/images/releases/boujeebish.jpg',
-    description: 'A playful, confident anthem.',
-    links: {
-      spotify: 'https://open.spotify.com/album/2PLFmLSQNH6Fk7DUcxWlyy',
-      apple: 'https://music.apple.com/album/boujeebish',
-    },
-    tracks: [
-      { id: '1', title: 'Boujee Bish', duration: '2:29' },
-    ],
-  },
-  {
-    id: 'alki-7',
-    title: 'My Life',
-    artist: 'Alki',
-    artistId: '1',
-    type: 'single',
-    releaseDate: new Date('2024-08-15'),
-    coverArt: '/images/releases/mylife.jpg',
-    description: 'Personal storytelling at its finest.',
-    links: {
-      spotify: 'https://open.spotify.com/album/0ihB19wepnsHaX31huVCnu',
-      apple: 'https://music.apple.com/album/mylife',
-    },
-    tracks: [
-      { id: '1', title: 'My Life', duration: '2:43' },
-    ],
-  },
-  {
-    id: 'alki-8',
-    title: 'Love Me More',
-    artist: 'Alki',
-    artistId: '1',
-    type: 'single',
-    releaseDate: new Date('2024-07-10'),
-    coverArt: '/images/releases/lovememore.jpg',
-    description: 'An emotional exploration of love and longing.',
-    links: {
-      spotify: 'https://open.spotify.com/album/4IYoGtWUnfzzbxe4OXzNAR',
-      apple: 'https://music.apple.com/album/lovememore',
-    },
-    tracks: [
-      { id: '1', title: 'Love Me More', duration: '2:51' },
-    ],
-  },
-
-  // === 2022 RELEASES ===
-  {
-    id: 'alki-9',
-    title: 'Attached',
-    artist: 'Alki',
-    artistId: '1',
-    type: 'single',
-    releaseDate: new Date('2022-05-01'),
-    coverArt: '/images/releases/attached.jpg',
-    description: 'A vulnerable exploration of emotional attachment with 249K+ streams.',
-    links: {
-      spotify: 'https://open.spotify.com/album/4BZ9ZzcTJqXw8b7cqYkCB5',
-      apple: 'https://music.apple.com/album/attached',
-    },
-    tracks: [
-      { id: '1', title: 'Attached', duration: '2:18' },
-    ],
-  },
-
-  // === 2021 RELEASES ===
-  {
-    id: 'alki-10',
-    title: 'Switched Up',
-    artist: 'Alki',
-    artistId: '1',
-    type: 'single',
-    releaseDate: new Date('2021-09-20'),
-    coverArt: '/images/releases/switched-up.jpg',
-    description: 'Alki\'s breakthrough release with over 3 million streams. A defining moment in his catalog that showcases his unique blend of punk attitude and melodic sensibility.',
-    links: {
-      spotify: 'https://open.spotify.com/album/4EF7LaxKklISvrfAqVyWkl',
-      apple: 'https://music.apple.com/album/switched-up',
-    },
-    tracks: [
-      { id: '1', title: 'Switched Up', duration: '2:45' },
-    ],
-  },
-  {
-    id: 'alki-11',
-    title: 'Too Much',
-    artist: 'Alki',
-    artistId: '1',
-    type: 'single',
-    releaseDate: new Date('2021-08-15'),
-    coverArt: '/images/releases/too-much.jpg',
-    description: 'Another massive hit with 1.1M+ streams. Raw emotion meets polished production.',
-    links: {
-      spotify: 'https://open.spotify.com/album/2zZxWozolia2eFyaa6Vvf9',
-      apple: 'https://music.apple.com/album/too-much',
-    },
-    tracks: [
-      { id: '1', title: 'Too Much', duration: '2:31' },
-    ],
-  },
-  {
-    id: 'alki-12',
-    title: 'Planes',
-    artist: 'Alki',
-    artistId: '1',
-    type: 'single',
-    releaseDate: new Date('2021-07-10'),
-    coverArt: '/images/releases/planes.jpg',
-    description: 'A fan favorite with nearly 400K streams. Wanderlust meets introspection.',
-    links: {
-      spotify: 'https://open.spotify.com/album/4S8NsL7dMsYqqshMVzbreE',
-      apple: 'https://music.apple.com/album/planes',
-    },
-    tracks: [
-      { id: '1', title: 'Planes', duration: '1:57' },
-    ],
-  },
-
-  // === 2020 RELEASES ===
-  {
-    id: 'alki-13',
-    title: 'Deceiving',
-    artist: 'Alki',
-    artistId: '1',
-    type: 'single',
-    releaseDate: new Date('2020-06-05'),
-    coverArt: '/images/releases/deceiving.jpg',
-    description: 'One of Alki\'s most emotionally raw tracks with 810K+ streams. Heartbreak distilled into art.',
-    links: {
-      spotify: 'https://open.spotify.com/album/10eFlyNRLA19cGvfCedVIn',
-      apple: 'https://music.apple.com/album/deceiving',
-    },
-    tracks: [
-      { id: '1', title: 'Deceiving', duration: '3:02' },
-    ],
-  },
-]
 
 // ========================================
 // PARDYALONE RELEASES
@@ -568,53 +318,12 @@ const pardyaloneReleases: Release[] = [
 // COMBINED RELEASES (sorted by release date, newest first)
 // ========================================
 export const mockReleases: Release[] = [
-  ...alkiReleases,
   ...pardyaloneReleases,
 ].sort((a, b) => b.releaseDate.getTime() - a.releaseDate.getTime())
 
 export const mockNews: NewsPost[] = [
   {
     id: '1',
-    title: 'Alki Drops New Single "221" - A Raw Expression of Punk Rage',
-    slug: 'alki-221-release',
-    excerpt: 'Alki returns with his most aggressive track yet, "221" - an angsty rap record that pulls no punches. The 1:49 explosive track showcases the artist\'s signature blend of punk energy and raw emotion.',
-    content: `
-# Alki Drops New Single "221" - A Raw Expression of Punk Rage
-
-**January 17, 2025** - Independent artist Alki has released his latest single "221," a blistering 1:49 track that exemplifies his unique fusion of punk rock energy and modern rap delivery.
-
-## The Track
-
-"221" is a raw, unfiltered expression of frustration and anger. The track's aggressive production and Alki's fierce vocal delivery create an intense listening experience that's both cathartic and confrontational. At just under two minutes, the song packs a powerful punch without overstaying its welcome.
-
-"This track is pure emotion," Alki explains. "Sometimes you just need to scream into the void, and '221' is that scream. It's for everyone who's felt misunderstood, betrayed, or just fed up with the BS."
-
-## Building Momentum
-
-With nearly 46,000 monthly listeners on Spotify and a catalog that includes hits like "Switched Up" (3M+ streams), "Too Much" (1.1M+ streams), and "Deceiving" (810K+ streams), Alki continues to build a devoted following through his relentlessly honest approach to music.
-
-As Co-Founder of HLPFL Records, Alki represents the label's core philosophy: artist ownership, creative freedom, and authentic connection with fans. The independent release of "221" demonstrates how artists can maintain complete control while still reaching massive audiences.
-
-## What's Next
-
-"221" is available now on all streaming platforms. With over 300 unreleased tracks in the vault, fans can expect much more from Alki throughout 2025.
-
-**Stream "221":**
-- [Spotify](https://open.spotify.com/album/468FaHLWX75g0RJdoEUABD)
-- [Apple Music](https://music.apple.com/album/221-single/1853361772)
-
-**Follow Alki:**
-- Instagram: [@alkiotis](https://www.instagram.com/alkiotis)
-- Spotify: [Alki](https://open.spotify.com/artist/1Jof1vMpSF5pIWUvG9cizl)
-- Website: [alki.info](https://alki.info)
-    `,
-    publishedAt: new Date('2025-01-17'),
-    author: 'HLPFL Press Team',
-    category: 'Releases',
-    image: '/images/releases/221.png',
-  },
-  {
-    id: '2',
     title: 'Pardyalone Releases "It Was Always Me" - A Journey of Self-Discovery and Accountability',
     slug: 'pardyalone-it-was-always-me',
     excerpt: 'With 434K+ monthly listeners and 60M+ total streams, Pardyalone continues his evolution as one of alternative hip-hop\'s most authentic voices with this deeply personal new album about taking responsibility and finding yourself.',
@@ -686,74 +395,6 @@ With "It Was Always Me," that mission continues with added self-awareness and ar
     image: '/images/releases/pardy-it-was-always-me.jpg',
   },
   {
-    id: '3',
-    title: 'Alki Surpasses 3 Million Streams on "Switched Up" - An Independent Success Story',
-    slug: 'switched-up-milestone',
-    excerpt: 'Celebrating a major milestone as Alki\'s breakout hit continues to resonate with fans worldwide, proving independent artists can compete in the streaming era.',
-    content: `
-# Alki Surpasses 3 Million Streams on "Switched Up" - An Independent Success Story
-
-**December 15, 2024** - Independent artist Alki has officially crossed 3 million streams on his breakout single "Switched Up," a significant milestone that demonstrates the power of authentic artistry in the modern music landscape.
-
-## The Breakthrough
-
-Released in September 2021, "Switched Up" became Alki's defining track, resonating with listeners through its raw honesty and infectious melody. The song's success came organically, without traditional label push or radio play—a testament to the changing dynamics of music discovery in the streaming age.
-
-"When I wrote 'Switched Up,' I was going through a rough time dealing with people who turned their backs on me," Alki reflects. "I never expected it to connect with so many people, but I think everyone's experienced that feeling of betrayal. The song just hit different."
-
-## The Numbers Tell a Story
-
-- **3,000,000+ streams** on Spotify alone
-- **45,900+ monthly listeners** across platforms
-- **Zero major label support** - completely independent
-- **100% artist ownership** - Alki owns his masters
-
-## The HLPFL Model
-
-As Co-Founder of HLPFL Records alongside James Rockel, Alki represents a new paradigm in the music industry. The label's revolutionary 50/50 partnership model ensures artists maintain ownership while receiving comprehensive support.
-
-"Too many artists get screwed over by traditional deals," says James Rockel, HLPFL Founder & CEO. "Alki's success with 'Switched Up' proves you don't need to sell your soul to make it in this industry. You need great music and smart partnerships."
-
-## What This Means for Independent Artists
-
-Alki's milestone is more than just a personal achievement—it's a blueprint for independent artists everywhere:
-
-1. **Ownership Matters**: Alki earns from every stream because he owns his masters
-2. **Authenticity Wins**: No focus groups or A&R committees—just honest music
-3. **Direct Connection**: Building relationships with fans through social media and platforms
-4. **Long-Term Thinking**: Success doesn't happen overnight, but it's sustainable
-
-## The Catalog Continues to Grow
-
-While "Switched Up" remains Alki's most-streamed track, his catalog continues to expand:
-- "Too Much" - 1.1M+ streams
-- "Deceiving" - 810K+ streams
-- "Planes" - 400K+ streams
-- "Attached" - 249K+ streams
-
-With 37+ released tracks and over 300 unreleased songs ready to drop, Alki's journey is just beginning.
-
-## Streaming Now
-
-Experience the track that started it all:
-- [Stream "Switched Up" on Spotify](https://open.spotify.com/album/4EF7LaxKklISvrfAqVyWkl)
-- [Apple Music](https://music.apple.com/album/switched-up)
-
-**Follow Alki:**
-- Instagram: [@alkiotis](https://www.instagram.com/alkiotis)
-- Twitter: [@alkiotis](https://twitter.com/alkiotis)
-- Spotify: [Alki Artist Page](https://open.spotify.com/artist/1Jof1vMpSF5pIWUvG9cizl)
-
----
-
-*About HLPFL Records: An independent record label and artist management platform that protects artists from exploitation. Founded on the principle of "Tools, Not Contracts," HLPFL provides comprehensive support while ensuring artists maintain 100% ownership of their work.*
-    `,
-    publishedAt: new Date('2024-12-15'),
-    author: 'HLPFL Press Team',
-    category: 'News',
-    image: '/images/releases/switched-up.jpg',
-  },
-  {
     id: '4',
     title: 'HLPFL Records Welcomes Priv to the Roster - The Future of Alternative Music',
     slug: 'priv-joins-hlpfl',
@@ -789,8 +430,9 @@ While details about upcoming releases are being kept under wraps, Priv has been 
 
 Priv joins an impressive roster that includes:
 
-- **Alki** (Co-Founder) - 46K+ monthly listeners, 3M+ streams on "Switched Up"
 - **Pardyalone** - 436K+ monthly listeners, 60M+ total streams, breakthrough hit "Not a Home" (26M+ streams)
+- **Writ3rs Block** - Music collective pushing boundaries with psychedelic and experimental sounds
+- **Adam Rodway** - Rising Pop/Rock artist from Toronto with tracks featured on Hockey Night In Canada
 
 Together, these artists represent HLPFL's commitment to supporting diverse voices who prioritize artistic integrity over commercial compromise.
 
@@ -832,110 +474,6 @@ Follow Priv's journey as they prepare to release new music and connect with fans
     publishedAt: new Date('2026-01-08'),
     author: 'HLPFL Press Team',
     category: 'News',
-    image: '/images/team/alki.webp',
-  },
-  {
-    id: '5',
-    title: 'From Bedroom Producer to 46K Monthly Listeners: Inside Alki\'s Independent Rise',
-    slug: 'alki-independent-success-story',
-    excerpt: 'How Alki built a thriving music career without a traditional record deal, proving that artists don\'t need to sacrifice ownership for success.',
-    content: `
-# From Bedroom Producer to 46K Monthly Listeners: Inside Alki's Independent Rise
-
-**January 5, 2026** - In an industry dominated by major labels and massive marketing budgets, Alkiviadis Halkiotis—known professionally as Alki—has carved his own path to success, building a devoted following of nearly 46,000 monthly Spotify listeners while maintaining 100% ownership of his music.
-
-## The Journey
-
-Born Alkiviadis Halkiotis, Alki didn't follow the traditional music industry playbook. No reality TV appearances. No major label showcases. No compromises.
-
-"I started making music in my bedroom because I had things I needed to say," Alki recalls. "I never set out to 'make it' in the traditional sense. I just wanted to create honest music and connect with people who felt the same things I did."
-
-That authenticity has resonated powerfully. With millions of streams across platforms and a catalog of 37+ released tracks (plus 300+ unreleased), Alki has proven that independent artists can compete—and thrive—in the streaming era.
-
-## The Sound
-
-Alki's music defies easy categorization. Blending punk energy, pop hooks, and raw rap delivery, he's created a sound that's uniquely his own.
-
-**Top Tracks:**
-- "Switched Up" - 3,000,000+ streams
-- "Too Much" - 1,100,000+ streams
-- "Deceiving" - 810,000+ streams
-- "Planes" - 400,000+ streams
-
-"I grew up listening to everything," Alki explains. "Why limit yourself to one genre? The best music comes from experimentation and honesty, not staying in your lane."
-
-## The Business Model
-
-Perhaps Alki's most significant achievement isn't musical—it's entrepreneurial. As Co-Founder of HLPFL Records alongside James Rockel, Alki has helped create a new model for artist partnerships.
-
-**The HLPFL Philosophy:**
-1. **Artists Keep Their Masters** - 100% ownership, always
-2. **Transparent Revenue Sharing** - Fair 50/50 split on label services
-3. **Comprehensive Tools** - Everything needed to build a career
-4. **No Hidden Fees** - Complete transparency
-5. **Artist-First Decision Making** - Artists drive the strategy
-
-"James and I started HLPFL because we were tired of seeing talented artists get screwed over," Alki states. "Traditional record deals are designed to benefit the label, not the artist. We flipped that model completely."
-
-## The Numbers Don't Lie
-
-**Alki's Independent Success:**
-- 45,900+ monthly Spotify listeners
-- 37+ released tracks
-- 300+ unreleased tracks ready to drop
-- Millions of streams across platforms
-- Zero label debt
-- 100% master ownership
-- Direct fan relationships
-- Sustainable career trajectory
-
-## The Strategy
-
-How did Alki achieve this level of success independently? The strategy is surprisingly straightforward:
-
-### 1. Consistent Output
-"I don't wait for inspiration. I create constantly. Some tracks hit, some don't, but you have to keep releasing to find what resonates."
-
-### 2. Authentic Connection
-"Social media is powerful when you're real with people. I don't post curated BS. I share my actual life—the good, the bad, the messy."
-
-### 3. Smart Partnerships
-"HLPFL gives me access to distribution, marketing tools, and infrastructure without taking my ownership. That's the key."
-
-### 4. Long-Term Thinking
-"Success isn't viral moments. It's building a catalog that continues to earn and connect with people over years, not weeks."
-
-## The Impact
-
-Alki's success has implications beyond his own career. As independent artists increasingly question the value of traditional record deals, Alki serves as a case study in what's possible.
-
-"You don't need a major label," he emphasizes. "You need great music, smart tools, and the willingness to work. Everything else is noise."
-
-## What's Next
-
-With over 300 unreleased tracks and a growing platform through HLPFL, Alki's trajectory is only pointing upward.
-
-"I'm just getting started," he says. "The music industry tried to tell artists they needed labels to succeed. We're proving that's bullshit. Artists just need ownership, tools, and honesty."
-
-## Listen Now
-
-Experience Alki's music:
-- [Spotify Artist Page](https://open.spotify.com/artist/1Jof1vMpSF5pIWUvG9cizl)
-- [Latest Release "221"](https://open.spotify.com/album/468FaHLWX75g0RJdoEUABD)
-- [Grouped Profile](https://app.grouped.com/everythingalki)
-
-**Follow Alki:**
-- Instagram: [@alkiotis](https://www.instagram.com/alkiotis)
-- Twitter: [@alkiotis](https://twitter.com/alkiotis)
-- Website: [alki.info](https://alki.info)
-
----
-
-*This article is part of HLPFL Records' ongoing series highlighting independent artists who are redefining success in the modern music industry.*
-    `,
-    publishedAt: new Date('2026-01-05'),
-    author: 'HLPFL Editorial Team',
-    category: 'Features',
     image: '/images/team/alki.webp',
   },
   {
@@ -1192,18 +730,6 @@ export const mockTeam: TeamMember[] = [
     socials: {
       linkedin: 'https://www.linkedin.com/in/jamesrockel',
       email: 'founder@hlpfl.org',
-    },
-  },
-  {
-    id: '2',
-    name: 'Alki',
-    role: 'Co-Founder & Signed Artist',
-    bio: 'Boundary-pushing artist creating the future of alternative music. As HLPFL\'s first signed artist and co-founder, Alki embodies our revolutionary artist-first philosophy. With a unique blend of punk, pop, and rap, Alki is proving that independent artists can thrive with the right partnership. Nearly 46,000 monthly listeners and millions of streams.',
-    image: '/images/team/alki.webp',
-    socials: {
-      instagram: 'https://instagram.com/alkiotis',
-      spotify: 'https://open.spotify.com/artist/1Jof1vMpSF5pIWUvG9cizl',
-      website: 'https://alki.info',
     },
   },
 ]


### PR DESCRIPTION
- Reordered artists: PRIV #1, Pardyalone #2, Writ3rs Block #3, Adam Rodway #4
- Removed all Alki releases and news posts
- Updated About page to remove Alki references and update artist count
- Updated Contact page to remove co-founder mention
- Removed Alki from team members
- Updated Priv news post to list current roster
- Verified artist portal login (demo@hlpfl.org / demo123 working)