### PR TITLE
Fix dashboard pages to use correct artist ID (PRIV)

### DIFF
--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -32,7 +32,7 @@ export default function AnalyticsDashboard() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const artistId = 'artist-alki-001'
+  const artistId = 'artist-priv-001'
 
   useEffect(() => {
     async function loadAnalytics() {

--- a/src/app/dashboard/community/page.tsx
+++ b/src/app/dashboard/community/page.tsx
@@ -50,7 +50,7 @@ export default function CommunityFeed() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const artistId = 'artist-alki-001'
+  const artistId = 'artist-priv-001'
 
   useEffect(() => {
     async function loadCommunity() {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -39,8 +39,8 @@ export default function DashboardPage() {
     }
   }, [router])
 
-  // Use Alki as default artist (in production, get from auth context)
-  const artistId = 'artist-alki-001'
+  // Use PRIV as default artist (in production, get from auth context)
+  const artistId = 'artist-priv-001'
 
   useEffect(() => {
     async function loadDashboard() {
@@ -207,7 +207,7 @@ export default function DashboardPage() {
     <div className="space-y-6">
       {/* Welcome Header */}
       <div>
-        <h1 className="text-3xl font-bold text-white mb-2">Welcome back, Alki 👋</h1>
+        <h1 className="text-3xl font-bold text-white mb-2">Welcome back, PRIV</h1>
         <p className="text-gray-400">Here's what's happening with your music today</p>
       </div>
 

--- a/src/app/dashboard/releases/page.tsx
+++ b/src/app/dashboard/releases/page.tsx
@@ -54,8 +54,8 @@ export default function ReleasesPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  // Use Alki as default artist
-  const artistId = 'artist-alki-001'
+  // Use PRIV as default artist
+  const artistId = 'artist-priv-001'
 
   useEffect(() => {
     async function loadReleases() {

--- a/src/app/dashboard/revenue/page.tsx
+++ b/src/app/dashboard/revenue/page.tsx
@@ -29,7 +29,7 @@ export default function RevenuePage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const artistId = 'artist-alki-001'
+  const artistId = 'artist-priv-001'
 
   useEffect(() => {
     async function loadRevenue() {


### PR DESCRIPTION
All dashboard pages were using the old artist ID 'artist-alki-001' which no longer exists after Alki was removed from the platform. Updated all 5 dashboard pages to use 'artist-priv-001' (PRIV) so they can fetch and display data correctly.

- Overview: Updated artistId and welcome message
- Analytics: Updated artistId
- Community: Updated artistId
- Revenue: Updated artistId
- Releases: Updated artistId