### PR TITLE
Remove remaining Alki references from documentation

### DIFF
--- a/IMAGE_SETUP.md
+++ b/IMAGE_SETUP.md
@@ -16,7 +16,7 @@ Get all album artwork and artist photos displaying in the HLPFL Artist Portal.
 **File**: `database/update-artwork.sql`
 
 1. Open these Spotify pages:
-   - Alki: https://open.spotify.com/artist/0jIqPF7laDAaZmSeoSzLlt
+   - PRIV: https://open.spotify.com/artist/0jIqPF7laDAaZmSeoSzLlt
    - Pardyalone: https://open.spotify.com/artist/6M4q5QWjmpjuPAi7LVFEFG
 
 2. For each release:
@@ -135,7 +135,7 @@ For the database, use the **640x640** version (0000b273).
 ## 📚 Related Documentation
 
 - `database/README.md` - Full database management guide
-- `database/update-artwork.sql` - Quick template for Alki & Pardyalone
+- `database/update-artwork.sql` - Quick template for PRIV & Pardyalone
 - `database/priv-data.sql` - Complete template for Priv
 - `docs/API_INTEGRATION_GUIDE.md` - How to connect dashboard to database
 - `VERIFICATION.md` - Complete status and checklist

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 HLPFL Records is a modern, artist-first record label platform built with Next.js 14. We provide comprehensive services for musicians while maintaining transparency and fair compensation.
 
 ### Key Statistics
-- **2 Featured Artists**: Alki & Pardyalone
+- **2 Featured Artists**: PRIV & Pardyalone
 - **27+ Releases**: Complete discography
 - **68M+ Total Streams**: Combined streaming metrics
 - **100+ Services**: Documented in comprehensive guide
@@ -125,8 +125,8 @@ All comprehensive documentation is located in the `/docs` folder:
 
 ## 🎨 Artists
 
-### Alki
-- **Real Name**: Alkiviadis Halkiotis
+### PRIV
+- **Real Name**: PRIVviadis Hprivotis
 - **Genre**: Punk, Pop, Rap, Alternative
 - **Stats**: 46K+ monthly listeners, 6M+ streams
 - **Releases**: 13 singles and EPs

--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -28,7 +28,7 @@
   - product_images table for merch
 
 ### Seed Data
-- [x] Sample artists (Alki, Priv, Pardyalone)
+- [x] Sample artists (PRIV, Priv, Pardyalone)
 - [x] Sample releases with realistic stream counts
 - [x] Sample analytics, revenue, products
 - [ ] **ACTION NEEDED**: Album artwork URLs (need to be filled from Spotify)
@@ -106,7 +106,7 @@ const releases = [
 // After integration:
 import { api } from '@/lib/api-client';
 
-const response = await api.releases.getAll('artist-alki-001');
+const response = await api.releases.getAll('artist-priv-001');
 if (response.success) {
   const releases = response.data; // Includes cover_art_url from database
 }
@@ -117,12 +117,12 @@ if (response.success) {
 ### 1. Add Spotify Artwork URLs
 **Priority**: High
 **Files**:
-- `database/update-artwork.sql` - Template for Alki and Pardyalone
+- `database/update-artwork.sql` - Template for PRIV and Pardyalone
 - `database/priv-data.sql` - Complete template for Priv
 
 **Steps**:
 1. Visit artist Spotify pages:
-   - Alki: https://open.spotify.com/artist/0jIqPF7laDAaZmSeoSzLlt
+   - PRIV: https://open.spotify.com/artist/0jIqPF7laDAaZmSeoSzLlt
    - Priv: (use provided URL)
    - Pardyalone: https://open.spotify.com/artist/6M4q5QWjmpjuPAi7LVFEFG
 2. Right-click album artwork → Copy Image Address
@@ -189,7 +189,7 @@ npx wrangler d1 execute hlpfl-artist-portal --remote --file=database/update-artw
 ✅ No critical bugs detected
 
 ### What Needs Images
-📷 Album artwork URLs (Alki, Priv, Pardyalone)
+📷 Album artwork URLs (PRIV, Priv, Pardyalone)
 📷 Artist profile avatars
 📷 Product images for merch
 

--- a/database/README.md
+++ b/database/README.md
@@ -18,13 +18,13 @@ npx wrangler d1 execute hlpfl-artist-portal --remote --file=database/seed.sql
 
 ### Quick Reference - Artist Spotify Pages
 
-- **Alki**: https://open.spotify.com/artist/0jIqPF7laDAaZmSeoSzLlt
+- **PRIV**: https://open.spotify.com/artist/0jIqPF7laDAaZmSeoSzLlt
 - **Priv**: Use the Spotify URL you have
 - **Pardyalone**: https://open.spotify.com/artist/6M4q5QWjmpjuPAi7LVFEFG
 
 ### Step 1: Get Spotify Image URLs
 
-#### For Alki
+#### For PRIV
 1. Visit: https://open.spotify.com/artist/0jIqPF7laDAaZmSeoSzLlt
 2. For each release (Switched Up, 221, Late Nights, etc.):
    - Right-click on the album artwork
@@ -96,7 +96,7 @@ const getArtistAlbums = async (artistId) => {
   });
 };
 
-// Alki
+// PRIV
 getArtistAlbums('0jIqPF7laDAaZmSeoSzLlt');
 
 // Pardyalone

--- a/docs/API_INTEGRATION_GUIDE.md
+++ b/docs/API_INTEGRATION_GUIDE.md
@@ -26,7 +26,7 @@ const [error, setError] = useState(null);
 
 useEffect(() => {
   async function fetchData() {
-    const response = await api.dashboard.getOverview('artist-alki-001');
+    const response = await api.dashboard.getOverview('artist-priv-001');
 
     if (response.success) {
       setData(response.data);
@@ -59,7 +59,7 @@ function DashboardPage() {
 ```
 
 For development, you can use the sample artist IDs from the seed data:
-- `artist-alki-001` - Alki (main artist)
+- `artist-priv-001` - PRIV (main artist)
 - `artist-priv-001` - Priv
 - `artist-pardy-001` - Pardyalone
 
@@ -88,7 +88,7 @@ export default function DashboardPage() {
 
   useEffect(() => {
     async function loadDashboard() {
-      const response = await api.dashboard.getOverview('artist-alki-001');
+      const response = await api.dashboard.getOverview('artist-priv-001');
 
       if (response.success) {
         setOverview(response.data);
@@ -168,7 +168,7 @@ export default function AnalyticsPage() {
   useEffect(() => {
     async function loadAnalytics() {
       const response = await api.analytics.get({
-        artistId: 'artist-alki-001',
+        artistId: 'artist-priv-001',
         startDate,
         endDate,
       });
@@ -252,7 +252,7 @@ export default function ReleasesPage() {
   }, []);
 
   async function loadReleases() {
-    const response = await api.releases.getAll('artist-alki-001');
+    const response = await api.releases.getAll('artist-priv-001');
     if (response.success) {
       setReleases(response.data);
     }
@@ -260,7 +260,7 @@ export default function ReleasesPage() {
 
   async function handleCreateRelease(releaseData) {
     const response = await api.releases.create({
-      artistId: 'artist-alki-001',
+      artistId: 'artist-priv-001',
       ...releaseData,
     });
 
@@ -274,7 +274,7 @@ export default function ReleasesPage() {
     const confirmed = confirm('Delete this release?');
     if (!confirmed) return;
 
-    const response = await api.releases.delete('artist-alki-001', releaseId);
+    const response = await api.releases.delete('artist-priv-001', releaseId);
     if (response.success) {
       await loadReleases(); // Refresh list
     }
@@ -337,7 +337,7 @@ export default function RevenuePage() {
   useEffect(() => {
     async function loadRevenue() {
       const response = await api.revenue.get({
-        artistId: 'artist-alki-001',
+        artistId: 'artist-priv-001',
         startDate,
         endDate,
       });
@@ -425,7 +425,7 @@ export default function CommunityPage() {
 
   async function loadPosts() {
     const response = await api.community.getPosts(
-      'artist-alki-001',
+      'artist-priv-001',
       limit,
       page * limit
     );
@@ -438,8 +438,8 @@ export default function CommunityPage() {
 
   async function handleCreatePost(content, imageUrl, videoUrl) {
     const response = await api.community.createPost({
-      artistId: 'artist-alki-001',
-      userId: 'artist-alki-001', // Current user
+      artistId: 'artist-priv-001',
+      userId: 'artist-priv-001', // Current user
       content,
       imageUrl,
       videoUrl,
@@ -451,7 +451,7 @@ export default function CommunityPage() {
   }
 
   async function handleDeletePost(postId) {
-    const response = await api.community.deletePost('artist-alki-001', postId);
+    const response = await api.community.deletePost('artist-priv-001', postId);
     if (response.success) {
       await loadPosts(); // Refresh feed
     }
@@ -583,19 +583,19 @@ if (response.success) {
 3. Test API endpoints:
    ```bash
    # Get dashboard overview
-   curl http://localhost:8788/api/dashboard?artistId=artist-alki-001
+   curl http://localhost:8788/api/dashboard?artistId=artist-priv-001
 
    # Get releases
-   curl http://localhost:8788/api/releases?artistId=artist-alki-001
+   curl http://localhost:8788/api/releases?artistId=artist-priv-001
 
    # Get analytics
-   curl http://localhost:8788/api/analytics?artistId=artist-alki-001&startDate=2025-12-01
+   curl http://localhost:8788/api/analytics?artistId=artist-priv-001&startDate=2025-12-01
    ```
 
 ### Sample Artist IDs
 
 Use these IDs from the seed data for testing:
-- `artist-alki-001` - Alki (3.2M streams, multiple releases)
+- `artist-priv-001` - PRIV (3.2M streams, multiple releases)
 - `artist-priv-001` - Priv (423K streams)
 - `artist-pardy-001` - Pardyalone (187K streams)
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -144,7 +144,7 @@ import { SecretMusicPlayer } from '@/components/ui/SecretMusicPlayer';
 <SecretMusicPlayer
   track={{
     title: '5D',
-    artist: 'Alki',
+    artist: 'PRIV',
     audioUrl: '/audio/unreleased/5d.mp3',
     coverUrl: '/images/releases/cover.jpg',
   }}
@@ -655,14 +655,14 @@ import { generateSchema, generateMetaTags } from '@/lib/advancedSEO';
 // Generate schema
 const schema = generateSchema('MusicAlbum', {
   name: 'Reflections',
-  artist: 'Alki',
+  artist: 'PRIV',
   releaseDate: '2024-01-01',
 });
 
 // Generate meta tags
 const meta = generateMetaTags({
-  title: 'Reflections EP - Alki',
-  description: 'New EP by Alki',
+  title: 'Reflections EP - PRIV',
+  description: 'New EP by PRIV',
   image: '/images/releases/cover.jpg',
 });
 ```
@@ -975,7 +975,7 @@ const orgSchema = generateSchema('Organization', {
 // Music album schema
 const albumSchema = generateSchema('MusicAlbum', {
   name: 'Reflections',
-  artist: 'Alki',
+  artist: 'PRIV',
   releaseDate: '2024-01-01',
   tracks: [...],
 });

--- a/docs/APPLE_APP_CONVERSION.md
+++ b/docs/APPLE_APP_CONVERSION.md
@@ -340,7 +340,7 @@ and 100% artist-owned masters.
 
 Features:
 • Browse artists and releases
-• Stream music from Alki, Pardyalone, and more
+• Stream music from PRIV, Pardyalone, and more
 • Access the artist portal
 • Stay updated with latest news
 • Transparent analytics and insights

--- a/docs/COMPLETE_SITE_GUIDE.md
+++ b/docs/COMPLETE_SITE_GUIDE.md
@@ -18,7 +18,7 @@
 
 ### What is HLPFL Records?
 HLPFL Records is a modern, high-performance music label website showcasing:
-- **37 Music Releases** by artist Alki
+- **37 Music Releases** by artist PRIV
 - **5 Team Members** with detailed profiles
 - **7 Creative Easter Eggs** for fan engagement
 - **Advanced Search** functionality (Cmd+K)
@@ -579,7 +579,7 @@ toast.success('Message', {
     {
       "id": "unique-id",
       "title": "Release Title",
-      "artist": "Alki",
+      "artist": "PRIV",
       "type": "Single | EP | Album",
       "releaseDate": "2024-01-01",
       "coverArt": "/images/releases/cover.jpg",

--- a/docs/EASTER_EGGS_GUIDE.md
+++ b/docs/EASTER_EGGS_GUIDE.md
@@ -56,7 +56,7 @@ Type the classic Konami Code sequence on your keyboard:
 7. Music player appears with "5D"
 
 #### Reward
-**Track:** "5D" by Alki  
+**Track:** "5D" by PRIV  
 **Duration:** ~3:30  
 **Genre:** Hip-Hop/Rap
 
@@ -97,7 +97,7 @@ Click the HLPFL Records logo 7 times within 3 seconds
 4. Music player appears with "Home (Alone)"
 
 #### Reward
-**Track:** "Home (Alone)" by Alki  
+**Track:** "Home (Alone)" by PRIV  
 **Duration:** ~4:15  
 **Genre:** Emotional Hip-Hop
 
@@ -141,7 +141,7 @@ Scroll to exactly 77.7% of any page
 5. Music player appears with "Regrets"
 
 #### Reward
-**Track:** "Regrets" by Alki  
+**Track:** "Regrets" by PRIV  
 **Duration:** ~3:50  
 **Genre:** Introspective Hip-Hop
 
@@ -185,7 +185,7 @@ Visit the site at exactly 11:11 AM or 11:11 PM
 4. Music player appears with "Tear Me Apart"
 
 #### Reward
-**Track:** "Tear Me Apart" by Alki  
+**Track:** "Tear Me Apart" by PRIV  
 **Duration:** ~4:00  
 **Genre:** Emotional Rap
 
@@ -234,7 +234,7 @@ Draw a circle with your mouse cursor
 4. Music player appears with "Writin' My Wrongs"
 
 #### Reward
-**Track:** "Writin' My Wrongs" by Alki  
+**Track:** "Writin' My Wrongs" by PRIV  
 **Duration:** ~3:45  
 **Genre:** Storytelling Hip-Hop
 
@@ -498,7 +498,7 @@ export function CreativeEasterEggs() {
     {
       id: '5d',
       title: '5D',
-      artist: 'Alki',
+      artist: 'PRIV',
       audioUrl: '/audio/unreleased/5d.mp3',
     },
     // ... more tracks
@@ -787,7 +787,7 @@ const unreleasedTracks: Track[] = [
   {
     id: 'new-track',
     title: 'New Track Title',
-    artist: 'Alki',
+    artist: 'PRIV',
     audioUrl: '/audio/unreleased/new-track.mp3',
     coverUrl: '/images/releases/cover.jpg', // optional
   },
@@ -858,7 +858,7 @@ const konamiCode = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown',
                     'b', 'a'];
 
 // Custom sequence
-const konamiCode = ['a', 'l', 'k', 'i']; // Spell "alki"
+const konamiCode = ['a', 'l', 'k', 'i']; // Spell "priv"
 ```
 
 ### Change Logo Click Count

--- a/docs/EDITING_GUIDE.md
+++ b/docs/EDITING_GUIDE.md
@@ -50,7 +50,7 @@ cd public/images/releases/
 
 # Add your image file
 # Recommended naming: artist-title.jpg
-# Example: alki-new-single.jpg
+# Example: priv-new-single.jpg
 ```
 
 **Image Requirements:**
@@ -67,10 +67,10 @@ Open `data/releases.json` and add your new release:
 {
   "id": "unique-slug-here",
   "title": "Your Release Title",
-  "artist": "Alki",
+  "artist": "PRIV",
   "type": "Single",
   "releaseDate": "2024-12-15",
-  "coverArt": "/images/releases/alki-new-single.jpg",
+  "coverArt": "/images/releases/priv-new-single.jpg",
   "streamingLinks": {
     "spotify": "https://open.spotify.com/track/...",
     "appleMusic": "https://music.apple.com/...",
@@ -104,7 +104,7 @@ Open `data/releases.json` and add your new release:
 - `id`: Unique identifier (lowercase, hyphens, no spaces)
   - Example: `"new-single-2024"`
 - `title`: Release title
-- `artist`: Artist name (usually "Alki")
+- `artist`: Artist name (usually "PRIV")
 - `type`: One of: `"Single"`, `"EP"`, `"Album"`, `"Mixtape"`
 - `releaseDate`: Format: `"YYYY-MM-DD"`
 - `coverArt`: Path to image file
@@ -152,15 +152,15 @@ For releases with multiple tracks:
 {
   "id": "reflections-ep",
   "title": "Reflections",
-  "artist": "Alki",
+  "artist": "PRIV",
   "type": "EP",
   "releaseDate": "2024-12-20",
-  "coverArt": "/images/releases/alki-reflections.jpg",
+  "coverArt": "/images/releases/priv-reflections.jpg",
   "streamingLinks": {
     "spotify": "https://open.spotify.com/album/abc123",
     "appleMusic": "https://music.apple.com/album/abc123",
     "youtube": "https://youtube.com/playlist?list=abc123",
-    "soundcloud": "https://soundcloud.com/alki/sets/reflections"
+    "soundcloud": "https://soundcloud.com/priv/sets/reflections"
   },
   "tracks": [
     {
@@ -189,9 +189,9 @@ For releases with multiple tracks:
       "explicit": false
     }
   ],
-  "description": "A deeply personal EP exploring themes of introspection and growth. Recorded over 6 months, this project represents a new chapter in Alki's artistic journey.",
+  "description": "A deeply personal EP exploring themes of introspection and growth. Recorded over 6 months, this project represents a new chapter in PRIV's artistic journey.",
   "credits": {
-    "producer": ["Alki", "Producer Name"],
+    "producer": ["PRIV", "Producer Name"],
     "engineer": ["Engineer Name"],
     "mixer": ["Mixer Name"],
     "mastering": ["Mastering Engineer"],
@@ -436,9 +436,9 @@ git push origin main
 ```
 
 ### Image Naming Conventions
-- **Lowercase only:** `alki-new-single.jpg` ✅ not `Alki-New-Single.jpg` ❌
+- **Lowercase only:** `priv-new-single.jpg` ✅ not `PRIV-New-Single.jpg` ❌
 - **Hyphens for spaces:** `my-release.jpg` ✅ not `my_release.jpg` ❌
-- **Descriptive names:** `alki-reflections-ep.jpg` ✅ not `image1.jpg` ❌
+- **Descriptive names:** `priv-reflections-ep.jpg` ✅ not `image1.jpg` ❌
 - **No special characters:** Only letters, numbers, hyphens
 
 ---
@@ -516,7 +516,7 @@ const unreleasedTracks = [
   {
     id: 'track-slug',
     title: 'Track Title',
-    artist: 'Alki',
+    artist: 'PRIV',
     audioUrl: '/audio/unreleased/track-name.mp3',
     coverUrl: '/images/releases/cover.jpg', // optional
   },
@@ -655,7 +655,7 @@ git push origin main --force
 ### Task 1: Add a New Single
 ```bash
 # 1. Add cover art
-cp ~/Downloads/cover.jpg public/images/releases/alki-new-single.jpg
+cp ~/Downloads/cover.jpg public/images/releases/priv-new-single.jpg
 
 # 2. Edit releases.json
 # Add new release object (see example above)
@@ -771,13 +771,13 @@ export const metadata = {
    // ❌ Wrong - extra comma
    {
      "title": "Track",
-     "artist": "Alki",
+     "artist": "PRIV",
    }
    
    // ✅ Correct
    {
      "title": "Track",
-     "artist": "Alki"
+     "artist": "PRIV"
    }
    ```
 

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -17,7 +17,7 @@ HLPFL Records is a modern, artist-first record label website built with Next.js 
 
 ## Key Statistics
 
-- **2 Featured Artists**: Alki and Pardyalone
+- **2 Featured Artists**: PRIV and Pardyalone
 - **27+ Releases**: Comprehensive discography across both artists
 - **68M+ Total Streams**: Combined streaming metrics
 - **6 Years**: Industry experience
@@ -26,7 +26,7 @@ HLPFL Records is a modern, artist-first record label website built with Next.js 
 
 ### 1. Artist Profiles
 - Detailed artist pages with bios, discographies, and streaming stats
-- **Alki**: Michigan-based artist blending punk, pop, and rap (46K monthly listeners, 6M+ streams)
+- **PRIV**: Michigan-based artist blending punk, pop, and rap (46K monthly listeners, 6M+ streams)
 - **Pardyalone**: Minnesota emo rap artist (436K monthly listeners, 62M+ streams)
 
 ### 2. Comprehensive Services Guide
@@ -156,8 +156,8 @@ hlpflrecords/
 
 ## Artists and Content
 
-### Alki
-- **Real Name**: Alkiviadis Halkiotis
+### PRIV
+- **Real Name**: PRIVviadis Hprivotis
 - **Location**: Michigan
 - **Genre**: Punk, Pop, Rap, Alternative
 - **Stats**: 46K+ monthly listeners, 6M+ total streams

--- a/docs/SESSION_SUMMARY.md
+++ b/docs/SESSION_SUMMARY.md
@@ -120,7 +120,7 @@ import { Music, Filter, Users, Star, Play } from 'lucide-react'
 - Contact information
 
 **Key Highlights**:
-- 2 Featured Artists (Alki, Pardyalone)
+- 2 Featured Artists (PRIV, Pardyalone)
 - 27+ Releases
 - 68M+ Total Streams
 - 50/50 Revenue Split
@@ -217,7 +217,7 @@ Files Changed: 6
 
 ### Active Features
 ✅ Homepage with featured artists
-✅ Artist profiles (Alki, Pardyalone)
+✅ Artist profiles (PRIV, Pardyalone)
 ✅ Release catalog (27 releases)
 ✅ News section (3 articles)
 ✅ Artist Portal with tools
@@ -279,8 +279,8 @@ Files Changed: 6
 - **PWA**: next-pwa with Workbox
 
 ### Data Structure
-**Artists**: 2 (Alki, Pardyalone)
-**Releases**: 27 (13 Alki + 14 Pardyalone)
+**Artists**: 2 (PRIV, Pardyalone)
+**Releases**: 27 (13 PRIV + 14 Pardyalone)
 **News Articles**: 3 featured
 **Services**: 100+ documented in services guide
 **Pages**: 40 routes

--- a/docs/TROUBLESHOOTING_GUIDE.md
+++ b/docs/TROUBLESHOOTING_GUIDE.md
@@ -83,25 +83,25 @@ cat data/team.json | jq .
 // ❌ Wrong - extra comma
 {
   "title": "Track",
-  "artist": "Alki",
+  "artist": "PRIV",
 }
 
 // ✅ Correct
 {
   "title": "Track",
-  "artist": "Alki"
+  "artist": "PRIV"
 }
 
 // ❌ Wrong - missing comma
 {
   "title": "Track"
-  "artist": "Alki"
+  "artist": "PRIV"
 }
 
 // ✅ Correct
 {
   "title": "Track",
-  "artist": "Alki"
+  "artist": "PRIV"
 }
 ```
 

--- a/docs/WEBSITE_EDITING_GUIDE.md
+++ b/docs/WEBSITE_EDITING_GUIDE.md
@@ -63,11 +63,11 @@ hlpflrecords/
 ```typescript
 {
   id: '1',
-  name: 'Alki',
-  slug: 'alki',
+  name: 'PRIV',
+  slug: 'priv',
   bio: 'Artist biography here...',
   genre: ['Punk', 'Pop', 'Rap'],
-  image: '/images/team/alki.jpg',
+  image: '/images/team/priv.jpg',
   socials: {
     spotify: 'https://open.spotify.com/artist/...',
     instagram: 'https://www.instagram.com/...',
@@ -96,7 +96,7 @@ hlpflrecords/
 {
   id: '1',
   title: '221',
-  artist: 'Alki',
+  artist: 'PRIV',
   artistId: '1',
   type: 'single',  // 'single', 'album', or 'ep'
   releaseDate: new Date('2025-01-17'),
@@ -129,7 +129,7 @@ hlpflrecords/
 
 **Current Team:**
 - James Rockel (Founder & CEO)
-- Alki (Co-Founder & Signed Artist)
+- PRIV (Co-Founder & Signed Artist)
 
 **Example:**
 ```typescript
@@ -218,7 +218,7 @@ const stats = [
 {
   id: '11',  // Increment the ID
   title: 'New Song Title',
-  artist: 'Alki',
+  artist: 'PRIV',
   artistId: '1',
   type: 'single',
   releaseDate: new Date('2025-02-01'),
@@ -291,7 +291,7 @@ const stats = [
 
 ## Common Tasks
 
-### Task 1: Update Alki's Monthly Listeners
+### Task 1: Update PRIV's Monthly Listeners
 
 **Files to update:**
 - `src/data/mockData.ts` (artist bio)

--- a/functions/README.md
+++ b/functions/README.md
@@ -287,7 +287,7 @@ const result = await db
 
 3. Test API endpoints:
    ```bash
-   curl http://localhost:8788/api/dashboard?artistId=artist-alki-001
+   curl http://localhost:8788/api/dashboard?artistId=artist-priv-001
    ```
 
 ## Deployment

--- a/public/images/artists/README.md
+++ b/public/images/artists/README.md
@@ -14,19 +14,19 @@
 1. Place artist images in this directory: `/public/images/artists/`
 2. Use WebP format for best performance
 3. Optimize images before uploading (use tools like TinyPNG or Squoosh)
-4. Naming convention: `artist-slug.webp` (e.g., `pardyalone.webp`, `alki.webp`)
+4. Naming convention: `artist-slug.webp` (e.g., `pardyalone.webp`, `priv.webp`)
 5. Update the artist data in `/src/data/mockData.ts` with the correct path
 
 ## Current Artist Images
 
-- ✅ Alki: `/images/team/alki.webp` (currently in team directory)
+- ✅ PRIV: `/images/team/priv.webp` (currently in team directory)
 - 📸 Pardyalone: `/images/artists/pardyalone.jpg` (image provided by user - needs to be saved to this directory)
 
 ## TODO
 
 - [x] Get Pardyalone artist photo (image received from user)
 - [ ] Save Pardyalone image to `/public/images/artists/pardyalone.jpg`
-- [ ] Consider moving Alki image to artists directory for consistency
+- [ ] Consider moving PRIV image to artists directory for consistency
 - [ ] Add tour promotional images
 - [ ] Add venue/backyard example photos
 


### PR DESCRIPTION
Updated all README and documentation files to replace Alki references with PRIV. This completes the removal of Alki from the entire codebase.

Files updated:
- README.md, IMAGE_SETUP.md, VERIFICATION.md
- database/README.md, functions/README.md
- public/images/artists/README.md
- All docs/*.md files