### PR TITLE
Fix Next.js 15 compatibility issues

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -25,7 +25,6 @@ const nextConfig = {
   compress: true,
   generateEtags: false,
   reactStrictMode: true,
-  swcMinify: true,
 
   // Security headers
   async headers() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 // Note: Google Fonts are loaded via CSS in globals.css to avoid build-time network dependencies
-import dynamic from 'next/dynamic'
 import './globals.css'
 
 // Component Imports
@@ -12,11 +11,7 @@ import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { EnhancedErrorBoundary } from '@/components/EnhancedErrorBoundary'
 import { AccessibilityHelper } from '@/components/accessibility/AccessibilityHelper'
 import { ToastContainer } from '@/components/ui/Toast'
-
-// Dynamically import Chatbot with SSR disabled
-const Chatbot = dynamic(() => import('@/components/ui/Chatbot').then(mod => ({ default: mod.Chatbot })), {
-  ssr: false,
-})
+import { ChatbotWrapper } from '@/components/ui/ChatbotWrapper'
 
 // Font configuration - HLPFL Brand Typography
 // Using CSS font loading to avoid build-time network dependencies
@@ -365,7 +360,7 @@ export default function RootLayout({
                 {children}
               </main>
               <Footer />
-              <Chatbot />
+              <ChatbotWrapper />
               <CreativeEasterEggs />
             </div>
           </ErrorBoundary>

--- a/src/components/ui/ChatbotWrapper.tsx
+++ b/src/components/ui/ChatbotWrapper.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const Chatbot = dynamic(
+  () => import('@/components/ui/Chatbot').then(mod => ({ default: mod.Chatbot })),
+  { ssr: false }
+)
+
+export function ChatbotWrapper() {
+  return <Chatbot />
+}


### PR DESCRIPTION
- Create ChatbotWrapper client component for dynamic import with ssr:false (Server Components in Next.js 15 don't support dynamic() with ssr:false)
- Update layout.tsx to use ChatbotWrapper instead of inline dynamic import
- Remove deprecated swcMinify option from next.config.js (SWC minification is enabled by default in Next.js 15)