### PR TITLE
Fix recursive build invocation in Cloudflare Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "npx @cloudflare/next-on-pages",
-    "build:local": "next build",
+    "build": "next build",
+    "pages:build": "npx @cloudflare/next-on-pages",
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,10 @@ name = "hlpflrecords"
 compatibility_date = "2024-12-17"
 compatibility_flags = ["nodejs_compat"]
 
+# Build configuration for Cloudflare Pages
+[build]
+command = "npm run pages:build"
+
 # Cloudflare Pages configuration
 pages_build_output_dir = ".vercel/output/static"
 


### PR DESCRIPTION
- Change build script back to 'next build' for Vercel compatibility
- Add pages:build script for @cloudflare/next-on-pages
- Add [build] section to wrangler.toml with custom build command

This fixes the recursive loop where:
npm run build -> @cloudflare/next-on-pages -> vercel build -> npm run build (loop)

Now: npm run pages:build -> @cloudflare/next-on-pages -> vercel build -> npm run build -> next build (terminates)