### PR TITLE
Remove unsupported [build] section from wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,10 +2,6 @@ name = "hlpflrecords"
 compatibility_date = "2024-12-17"
 compatibility_flags = ["nodejs_compat"]
 
-# Build configuration for Cloudflare Pages
-[build]
-command = "npm run pages:build"
-
 # Cloudflare Pages configuration
 pages_build_output_dir = ".vercel/output/static"
 


### PR DESCRIPTION
The [build] command config isn't supported for Cloudflare Pages via wrangler.toml. Build command must be configured in the Cloudflare Pages dashboard instead. Set dashboard build command to: npm run pages:build