### PR TITLE
Add Edge Runtime config to all API routes for Cloudflare Pages

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,5 @@
 import { handlers } from '@/lib/auth'
 
+export const runtime = 'edge'
+
 export const { GET, POST } = handlers

--- a/src/app/api/blog/posts/[slug]/route.ts
+++ b/src/app/api/blog/posts/[slug]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { NewsPost } from '@/types';
 
+export const runtime = 'edge'
+
 // In-memory storage (in production, use a database)
 const blogPosts: NewsPost[] = [
   {

--- a/src/app/api/blog/posts/route.ts
+++ b/src/app/api/blog/posts/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { NewsPost } from '@/types';
 
+export const runtime = 'edge'
+
 // In-memory storage (replace with database in production)
 let blogPosts: NewsPost[] = [
   {

--- a/src/app/api/chatbot-analytics/route.ts
+++ b/src/app/api/chatbot-analytics/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { ChatbotAnalytics } from '@/lib/chatbotAnalytics'
 
+export const runtime = 'edge'
+
 // This is a simple in-memory storage for demonstration
 // In production, you'd want to use a proper database
 const analyticsData: Array<{

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import Stripe from 'stripe'
 
+export const runtime = 'edge'
+
 interface CheckoutItem {
   name: string
   price: number

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+export const runtime = 'edge'
+
 interface ContactFormData {
   name: string
   email: string

--- a/src/app/api/questionnaire/route.ts
+++ b/src/app/api/questionnaire/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+export const runtime = 'edge'
+
 interface QuestionnaireData {
   artistName: string
   legalName: string


### PR DESCRIPTION
Cloudflare Pages requires all non-static routes to use the Edge Runtime. Added `export const runtime = 'edge'` to:
- /api/auth/[...nextauth]
- /api/blog/posts/[slug]
- /api/blog/posts
- /api/chatbot-analytics
- /api/checkout
- /api/contact
- /api/questionnaire